### PR TITLE
Security Group rules restrict SSH

### DIFF
--- a/hooks/EC2_SecurityGroupRestrictedSSH/.gitignore
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/.gitignore
@@ -1,0 +1,130 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# contains credentials
+sam-tests/
+
+rpdk.log*
+/awscommunity-ec2-securitygrouprestrictedssh.zip

--- a/hooks/EC2_SecurityGroupRestrictedSSH/.rpdk-config
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/.rpdk-config
@@ -1,0 +1,21 @@
+{
+    "artifact_type": "HOOK",
+    "typeName": "AwsCommunity::EC2::SecurityGroupRestrictedSSH",
+    "language": "python37",
+    "runtime": "python3.7",
+    "entrypoint": "awscommunity_ec2_securitygrouprestrictedssh.handlers.hook",
+    "testEntrypoint": "awscommunity_ec2_securitygrouprestrictedssh.handlers.test_entrypoint",
+    "settings": {
+        "version": false,
+        "subparser_name": null,
+        "verbose": 0,
+        "force": false,
+        "type_name": null,
+        "artifact_type": null,
+        "endpoint_url": null,
+        "region": null,
+        "target_schemas": [],
+        "use_docker": true,
+        "protocolVersion": "2.0.0"
+    }
+}

--- a/hooks/EC2_SecurityGroupRestrictedSSH/README.md
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/README.md
@@ -1,3 +1,69 @@
 # AwsCommunity::EC2::SecurityGroupRestrictedSSH
 
 Validates a resource of type `AWS::EC2::SecurityGroup` and ``AWS::EC2::SecurityGroupIngress` to validate no security group rules allow port 22 (SSH) to `0.0.0.0/0`.
+
+This will hook will fail on:
+
+```yaml
+Resources:
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "TestingSomeRules"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          ToPort: 22
+          FromPort: 22
+          CidrIp: 0.0.0.0/0
+```
+
+or
+
+```yaml
+Resources:
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+    GroupDescription: "TestingSomeRules"
+  SecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+      ToPort: 22
+      FromPort: 22
+      CidrIp: 0.0.0.0/0
+```
+
+It will pass on
+
+```yaml
+Resources:
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "TestingSomeRules"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          ToPort: 443
+          FromPort: 443
+          CidrIp: 0.0.0.0/0
+```
+
+and
+
+```yaml
+Resources:
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+    GroupDescription: "TestingSomeRules"
+  SecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref SecurityGroup
+      IpProtocol: tcp
+      ToPort: 22
+      FromPort: 22
+      CidrIp: 10.0.0.0/16
+```

--- a/hooks/EC2_SecurityGroupRestrictedSSH/README.md
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/README.md
@@ -1,0 +1,3 @@
+# AwsCommunity::EC2::SecurityGroupRestrictedSSH
+
+Validates a resource of type `AWS::EC2::SecurityGroup` and ``AWS::EC2::SecurityGroupIngress` to validate no security group rules allow port 22 (SSH) to `0.0.0.0/0`.

--- a/hooks/EC2_SecurityGroupRestrictedSSH/awscommunity-ec2-securitygrouprestrictedssh-configuration.json
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/awscommunity-ec2-securitygrouprestrictedssh-configuration.json
@@ -1,0 +1,6 @@
+{
+    "properties": {},
+    "additionalProperties": false,
+    "definitions": {},
+    "typeName": "AwsCommunity::EC2::SecurityGroupRestrictedSSH"
+}

--- a/hooks/EC2_SecurityGroupRestrictedSSH/awscommunity-ec2-securitygrouprestrictedssh.json
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/awscommunity-ec2-securitygrouprestrictedssh.json
@@ -1,0 +1,32 @@
+{
+    "typeName": "AwsCommunity::EC2::SecurityGroupRestrictedSSH",
+    "description": "Restrict SSH traffic from 0.0.0.0/0",
+    "sourceUrl": "https://github.com/aws-cloudformation/community-registry-extensions/hooks/EC2_SecurityGroupRestrictedSSH",
+    "documentationUrl": "https://github.com/aws-cloudformation/community-registry-extensions/blob/master/hooks/EC2_SecurityGroupRestrictedSSH/README.md",
+    "typeConfiguration": {
+        "properties": {},
+        "additionalProperties": false
+    },
+    "required": [],
+    "handlers": {
+        "preCreate": {
+            "targetNames": [
+                "AWS::EC2::SecurityGroup",
+                "AWS::EC2::SecurityGroupIngress"
+            ],
+            "permissions": []
+        },
+        "preUpdate": {
+            "targetNames": [
+                "AWS::EC2::SecurityGroup",
+                "AWS::EC2::SecurityGroupIngress"
+            ],
+            "permissions": []
+        },
+        "preDelete": {
+            "targetNames": [],
+            "permissions": []
+        }
+    },
+    "additionalProperties": false
+}

--- a/hooks/EC2_SecurityGroupRestrictedSSH/hook-role-prod.yaml
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/hook-role-prod.yaml
@@ -1,0 +1,33 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  This CloudFormation template creates a role assumed by CloudFormation
+  during Hook operations on behalf of the customer.
+
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      MaxSessionDuration: 8400
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - hooks.cloudformation.amazonaws.com
+                - resources.cloudformation.amazonaws.com
+            Action: sts:AssumeRole
+      Path: "/"
+      Policies:
+        - PolicyName: HookTypePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Deny
+                Action:
+                - "*"
+                Resource: "*"
+Outputs:
+  ExecutionRoleArn:
+    Value:
+      Fn::GetAtt: ExecutionRole.Arn

--- a/hooks/EC2_SecurityGroupRestrictedSSH/hook-role.yaml
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/hook-role.yaml
@@ -1,0 +1,40 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  This CloudFormation template creates a role assumed by CloudFormation
+  during Hook operations on behalf of the customer.
+
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      MaxSessionDuration: 8400
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - hooks.cloudformation.amazonaws.com
+                - resources.cloudformation.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/hook/AwsCommunity-EC2-SecurityGroupRestrictedSSH/*
+      Path: "/"
+      Policies:
+        - PolicyName: HookTypePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Deny
+                Action:
+                - "*"
+                Resource: "*"
+Outputs:
+  ExecutionRoleArn:
+    Value:
+      Fn::GetAtt: ExecutionRole.Arn

--- a/hooks/EC2_SecurityGroupRestrictedSSH/inputs/inputs_1_invalid_pre_create.json
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/inputs/inputs_1_invalid_pre_create.json
@@ -1,0 +1,22 @@
+{
+  "AWS::EC2::SecurityGroup": {
+    "resourceProperties": {
+      "SecurityGroupIngress": [
+        {
+          "ToPort": "22",
+          "FromPort": "22",
+          "IpProtocol": "tcp",
+          "CidrIp": "0.0.0.0/0"
+        }
+      ]
+    }
+  },
+  "AWS::EC2::SecurityGroupIngress": {
+    "resourceProperties": {
+      "ToPort": "22",
+      "FromPort": "22",
+      "IpProtocol": "tcp",
+      "CidrIp": "0.0.0.0/0"
+    }
+  }
+}

--- a/hooks/EC2_SecurityGroupRestrictedSSH/inputs/inputs_1_invalid_pre_update.json
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/inputs/inputs_1_invalid_pre_update.json
@@ -1,0 +1,28 @@
+{
+  "AWS::EC2::SecurityGroup": {
+    "resourceProperties": {
+      "SecurityGroupIngress": [
+        {
+          "ToPort": "443",
+          "FromPort": "443",
+          "IpProtocol": "tcp",
+          "CidrIp": "0.0.0.0/0"
+        },
+        {
+          "ToPort": "22",
+          "FromPort": "22",
+          "IpProtocol": "tcp",
+          "CidrIp": "0.0.0.0/0"
+        }
+      ]
+    }
+  },
+  "AWS::EC2::SecurityGroupIngress": {
+    "resourceProperties": {
+      "ToPort": "22",
+      "FromPort": "22",
+      "IpProtocol": "tcp",
+      "CidrIp": "0.0.0.0/0"
+    }
+  }
+}

--- a/hooks/EC2_SecurityGroupRestrictedSSH/inputs/inputs_1_pre_create.json
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/inputs/inputs_1_pre_create.json
@@ -1,0 +1,22 @@
+{
+  "AWS::EC2::SecurityGroup": {
+    "resourceProperties": {
+      "SecurityGroupIngress": [
+        {
+          "ToPort": "443",
+          "FromPort": "443",
+          "IpProtocol": "tcp",
+          "CidrIp": "0.0.0.0/0"
+        }
+      ]
+    }
+  },
+  "AWS::EC2::SecurityGroupIngress": {
+    "resourceProperties": {
+      "ToPort": "443",
+      "FromPort": "443",
+      "IpProtocol": "tcp",
+      "CidrIp": "0.0.0.0/0"
+    }
+  }
+}

--- a/hooks/EC2_SecurityGroupRestrictedSSH/inputs/inputs_1_pre_update.json
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/inputs/inputs_1_pre_update.json
@@ -1,0 +1,22 @@
+{
+  "AWS::EC2::SecurityGroup": {
+    "resourceProperties": {
+      "SecurityGroupIngress": [
+        {
+          "ToPort": "443",
+          "FromPort": "443",
+          "IpProtocol": "tcp",
+          "CidrIp": "0.0.0.0/0"
+        }
+      ]
+    }
+  },
+  "AWS::EC2::SecurityGroupIngress": {
+    "resourceProperties": {
+      "ToPort": "443",
+      "FromPort": "443",
+      "IpProtocol": "tcp",
+      "CidrIp": "0.0.0.0/0"
+    }
+  }
+}

--- a/hooks/EC2_SecurityGroupRestrictedSSH/requirements-dev.txt
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/requirements-dev.txt
@@ -1,7 +1,7 @@
 cfn-lint==0.64.1
-cloudformation-cli==0.2.25
-cloudformation-cli-python-lib==2.1.12
-cloudformation-cli-python-plugin==2.1.5
-git+https://github.com/kddejong/cloudformation-cli-python-plugin.git@fix/ecr/lambdaimage
+cloudformation-cli==0.2.28
+cloudformation-cli-python-lib==2.1.15
+cloudformation-cli-python-plugin==2.1.7
+git+https://github.com/aws-cloudformation/cloudformation-cli-python-plugin.git@master
 pylint==2.15.2
-pytest==7.1.3
+pytest==7.2.0

--- a/hooks/EC2_SecurityGroupRestrictedSSH/requirements-dev.txt
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/requirements-dev.txt
@@ -1,0 +1,7 @@
+cfn-lint==0.64.1
+cloudformation-cli==0.2.25
+cloudformation-cli-python-lib==2.1.12
+cloudformation-cli-python-plugin==2.1.5
+git+https://github.com/kddejong/cloudformation-cli-python-plugin.git@fix/ecr/lambdaimage
+pylint==2.15.2
+pytest==7.1.3

--- a/hooks/EC2_SecurityGroupRestrictedSSH/requirements.txt
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/requirements.txt
@@ -1,2 +1,3 @@
-cloudformation-cli-python-lib>=2.1.9
-cfn-guard-rs-hook>=0.1.1
+cloudformation-cli-python-lib>=2.1.15
+cfn-guard-rs-hook>=0.2.2
+cryptography<40.0.0

--- a/hooks/EC2_SecurityGroupRestrictedSSH/requirements.txt
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/requirements.txt
@@ -1,0 +1,2 @@
+cloudformation-cli-python-lib>=2.1.9
+cfn-guard-rs-hook>=0.1.1

--- a/hooks/EC2_SecurityGroupRestrictedSSH/src/awscommunity_ec2_securitygrouprestrictedssh/handler_test.py
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/src/awscommunity_ec2_securitygrouprestrictedssh/handler_test.py
@@ -1,0 +1,6 @@
+"Unit tests"
+
+def test():
+    "Placeholder"
+    assert True
+

--- a/hooks/EC2_SecurityGroupRestrictedSSH/src/awscommunity_ec2_securitygrouprestrictedssh/handlers.py
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/src/awscommunity_ec2_securitygrouprestrictedssh/handlers.py
@@ -1,0 +1,13 @@
+"Handler implementation for the hook"
+import logging
+from cfn_guard_rs_hook import GuardHook
+
+from . import rules as Rules
+from .models import TypeConfigurationModel
+
+# Use this logger to forward log messages to CloudWatch Logs.
+LOG = logging.getLogger(__name__)
+TYPE_NAME = "AwsCommunity::EC2::SecurityGroupRestrictedSSH"
+
+hook = GuardHook(TYPE_NAME, TypeConfigurationModel, Rules)
+test_entrypoint = hook.test_entrypoint

--- a/hooks/EC2_SecurityGroupRestrictedSSH/src/awscommunity_ec2_securitygrouprestrictedssh/models.py
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/src/awscommunity_ec2_securitygrouprestrictedssh/models.py
@@ -1,0 +1,52 @@
+# DO NOT modify this file by hand, changes will be overwritten
+import sys
+from dataclasses import dataclass
+from inspect import getmembers, isclass
+from typing import (
+    AbstractSet,
+    Any,
+    Generic,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+)
+
+from cloudformation_cli_python_lib.interface import BaseHookHandlerRequest, BaseModel
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+T = TypeVar("T")
+
+
+def set_or_none(value: Optional[Sequence[T]]) -> Optional[AbstractSet[T]]:
+    if value:
+        return set(value)
+    return None
+
+
+@dataclass
+class HookHandlerRequest(BaseHookHandlerRequest):
+    pass
+
+
+@dataclass
+class TypeConfigurationModel(BaseModel):
+
+    @classmethod
+    def _deserialize(
+        cls: Type["_TypeConfigurationModel"],
+        json_data: Optional[Mapping[str, Any]],
+    ) -> Optional["_TypeConfigurationModel"]:
+        if not json_data:
+            return None
+        return cls(
+        )
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_TypeConfigurationModel = TypeConfigurationModel
+
+

--- a/hooks/EC2_SecurityGroupRestrictedSSH/src/awscommunity_ec2_securitygrouprestrictedssh/rules/security_group.guard
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/src/awscommunity_ec2_securitygrouprestrictedssh/rules/security_group.guard
@@ -1,0 +1,16 @@
+let aws_security_groups_restricted_ssh = Resources.*[ 
+	Type == 'AWS::EC2::SecurityGroup'
+	some Properties.SecurityGroupIngress[*] {
+		ToPort == "22"
+		FromPort == "22"
+		IpProtocol == "tcp"
+	}
+]
+
+rule INCOMING_SSH_DISABLED when %aws_security_groups_restricted_ssh !empty {
+	%aws_security_groups_restricted_ssh.Properties.SecurityGroupIngress[*] != {CidrIp:"0.0.0.0/0", ToPort:"22", FromPort:"22", IpProtocol:"tcp"}
+  <<
+    Violation: IP addresses of the incoming SSH traffic in the security groups are restricted (CIDR other than 0.0.0.0/0)
+    Fix: set SecurityGroupIngress.CidrIp property to a more restrictive CIDR than 0.0.0.0/0
+  >>
+}

--- a/hooks/EC2_SecurityGroupRestrictedSSH/src/awscommunity_ec2_securitygrouprestrictedssh/rules/security_group_ingress.guard
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/src/awscommunity_ec2_securitygrouprestrictedssh/rules/security_group_ingress.guard
@@ -1,0 +1,16 @@
+let aws_security_groups_restricted_ssh = Resources.*[ 
+	Type == 'AWS::EC2::SecurityGroupIngress'
+	some Properties {
+		ToPort == "22"
+		FromPort == "22"
+		IpProtocol == "tcp"
+	}
+]
+
+rule INCOMING_SSH_DISABLED when %aws_security_groups_restricted_ssh !empty {
+	%aws_security_groups_restricted_ssh.Properties.SecurityGroupIngress[*] != {CidrIp:"0.0.0.0/0", ToPort:"22", FromPort:"22", IpProtocol:"tcp"}
+  <<
+    Violation: IP addresses of the incoming SSH traffic in the security groups are restricted (CIDR other than 0.0.0.0/0)
+    Fix: set SecurityGroupIngress.CidrIp property to a more restrictive CIDR than 0.0.0.0/0
+  >>
+}

--- a/hooks/EC2_SecurityGroupRestrictedSSH/template.yml
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/template.yml
@@ -1,0 +1,24 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: AWS SAM template for the AwsCommunity::EC2::SecurityGroupRestrictedSSH resource type
+
+Globals:
+  Function:
+    Timeout: 180  # docker start-up times can be long for SAM CLI
+    MemorySize: 256
+
+Resources:
+  TypeFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: awscommunity_ec2_securitygrouprestrictedssh.handlers.hook
+      Runtime: python3.7
+      CodeUri: build/
+
+  TestEntrypoint:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: awscommunity_ec2_securitygrouprestrictedssh.handlers.test_entrypoint
+      Runtime: python3.7
+      CodeUri: build/
+

--- a/hooks/EC2_SecurityGroupRestrictedSSH/test/configuration-undo.json
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/test/configuration-undo.json
@@ -1,0 +1,9 @@
+{
+  "CloudFormationConfiguration": {
+    "HookConfiguration": {
+      "TargetStacks": "NONE",
+      "FailureMode": "WARN",
+      "Properties": {}
+    }
+  }
+}

--- a/hooks/EC2_SecurityGroupRestrictedSSH/test/configuration.json
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/test/configuration.json
@@ -1,0 +1,9 @@
+{
+  "CloudFormationConfiguration": {
+    "HookConfiguration": {
+      "TargetStacks": "ALL",
+      "FailureMode": "FAIL",
+      "Properties": {}
+    }
+  }
+}

--- a/hooks/EC2_SecurityGroupRestrictedSSH/test/integ-fail.yml
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/test/integ-fail.yml
@@ -1,0 +1,10 @@
+Resources:
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "TestingSomeRules"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          ToPort: 22
+          FromPort: 22
+          CidrIp: 0.0.0.0/0

--- a/hooks/EC2_SecurityGroupRestrictedSSH/test/integ-succeed.yml
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/test/integ-succeed.yml
@@ -1,0 +1,10 @@
+Resources:
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "TestingSomeRules"
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          ToPort: 443
+          FromPort: 443
+          CidrIp: 0.0.0.0/0

--- a/hooks/alpha-buildspec-python.yml
+++ b/hooks/alpha-buildspec-python.yml
@@ -29,7 +29,7 @@ phases:
       - cfn submit --dry-run
       - nohup sam local start-lambda &
       - sleep 10
-      - cfn test
+      - cfn test --region $AWS_REGION # Region added: https://github.com/aws-cloudformation/cloudformation-cli/issues/625
     finally:
       - cat rpdk.log
 

--- a/release/awscommunity/cicd.yml
+++ b/release/awscommunity/cicd.yml
@@ -101,6 +101,19 @@ Resources:
       ManagedPolicyArns:
         - Fn::ImportValue: !Sub "cep-${Env}-common-build-project-policy"
 
+  HookEC2SecurityGroupRestrictedSSHBuildProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - Fn::ImportValue: !Sub "cep-${Env}-common-build-project-policy"
+
   CloudFrontLoggingEnabledBuildProjectRole:
     Type: AWS::IAM::Role
     Properties:
@@ -356,6 +369,21 @@ Resources:
       Roles:
         - !Ref ResourceIamPasswordPolicyRole
 
+  HookEC2SecurityGroupRestrictedSSHBuildProjectRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - ec2:*VPC*
+              - ec2:*SecurityGroup*
+            Effect: Allow
+            Resource: "*"
+        Version: '2012-10-17'
+      PolicyName: SecurityGroupPermissions
+      Roles:
+        - !Ref HookEC2SecurityGroupRestrictedSSHBuildProjectRole
+
   S3BucketNotificationBuildProject:
     Type: AWS::CodeBuild::Project
     Properties:
@@ -493,6 +521,30 @@ Resources:
           Type: PLAINTEXT
           Value: "placeholder-for-path-to-hook"
       ServiceRole: !GetAtt S3PublicAccessControlsRestrictedBuildProjectRole.Arn
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: !Sub "hooks/${Env}-buildspec-python.yml"
+      # BuildBatchConfig:
+      #   ServiceRole: !GetAtt S3BucketVersioningEnabledBuildProjectRole.Arn
+      TimeoutInMinutes: 480
+
+  HookEC2SecurityGroupRestrictedSSHBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub "${PrefixLower}-${Env}-ec2-securitygrouprestrictedssh"
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_LARGE
+        Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/cep-cicd:latest"
+        ImagePullCredentialsType: SERVICE_ROLE
+        PrivilegedMode: true
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+        - Name: HOOK_PATH
+          Type: PLAINTEXT
+          Value: "placeholder-for-path-to-hook"
+      ServiceRole: !GetAtt HookEC2SecurityGroupRestrictedSSHBuildProjectRole.Arn
       Source:
         Type: CODEPIPELINE
         BuildSpec: !Sub "hooks/${Env}-buildspec-python.yml"
@@ -674,6 +726,7 @@ Resources:
               - codebuild:StopBuildBatch
             Effect: Allow
             Resource: 
+              - !GetAtt HookEC2SecurityGroupRestrictedSSHBuildProject.Arn
               - !GetAtt S3BucketNotificationBuildProject.Arn
               - !GetAtt S3DeleteBucketContentsBuildProject.Arn
               - !GetAtt S3BucketVersioningEnabledBuildProject.Arn
@@ -735,6 +788,7 @@ Resources:
               AWS: 
                 - !GetAtt PipelineRole.Arn
                 - !Sub "arn:aws:iam::${ProdAccountId}:root"
+                - !GetAtt HookEC2SecurityGroupRestrictedSSHBuildProjectRole.Arn
                 - !GetAtt S3BucketNotificationBuildProjectRole.Arn
                 - !GetAtt S3DeleteBucketContentsBuildProjectRole.Arn
                 - !GetAtt S3BucketVersioningEnabledBuildProjectRole.Arn
@@ -916,6 +970,25 @@ Resources:
                       "name": "HOOK_PATH",
                       "type": "PLAINTEXT",
                       "value": "hooks/S3_BucketVersioningEnabled"
+                    }
+                  ]
+              RunOrder: 2
+            - Name: HookEC2SecurityGroupRestrictedSSH
+              InputArtifacts:
+                - Name: extensions-source
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: 1
+              Configuration:
+                ProjectName: !Ref HookEC2SecurityGroupRestrictedSSHBuildProject
+                EnvironmentVariables: |-
+                  [
+                    {
+                      "name": "HOOK_PATH",
+                      "type": "PLAINTEXT",
+                      "value": "hooks/EC2_SecurityGroupRestrictedSSH"
                     }
                   ]
               RunOrder: 2

--- a/resources/alpha-buildspec-python.yml
+++ b/resources/alpha-buildspec-python.yml
@@ -38,7 +38,7 @@ phases:
       - cfn submit --dry-run
       - nohup sam local start-lambda &
       - sleep 10
-      - cfn test
+      - cfn test --region $AWS_REGION # Region added: https://github.com/aws-cloudformation/cloudformation-cli/issues/625
     finally:
       - cat rpdk.log
       - rain rm $SETUP_STACK_NAME -y

--- a/resources/alpha-buildspec-typescript.yml
+++ b/resources/alpha-buildspec-typescript.yml
@@ -33,7 +33,7 @@ phases:
       - cfn submit --dry-run
       - nohup sam local start-lambda &
       - sleep 10
-      - cfn test
+      - cfn test --region $AWS_REGION # Region added: https://github.com/aws-cloudformation/cloudformation-cli/issues/625
     finally:
       - cat rpdk.log
       - ./cleanup.sh


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add a hook to validate `AWS::EC2::SecurityGroup` and `AWS::EC2::SecurityGroupIngress` to validate no security group rules allow port 22 (SSH) to `0.0.0.0/0`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
