### PR TITLE
fix(package) - have cfn_guard_rs return errors when given from guard

### DIFF
--- a/packages/cfn_guard_rs/Cargo.lock
+++ b/packages/cfn_guard_rs/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cfn-guard"
 version = "2.1.0"
-source = "git+https://github.com/aws-cloudformation/cloudformation-guard?tag=2.1.0#901d40a6f01553d14adf9ab398c7eec55c2b5a36"
+source = "git+https://github.com/aws-cloudformation/cloudformation-guard?branch=main#eb02492ea7963970fe2a46480cb53a58831f55ce"
 dependencies = [
  "Inflector",
  "clap",
@@ -102,14 +102,15 @@ dependencies = [
  "nom",
  "nom_locate",
  "regex",
+ "rstest",
  "serde",
  "serde_json",
  "serde_yaml",
  "simple_logger",
  "string-builder",
+ "unsafe-libyaml",
  "urlencoding",
  "walkdir",
- "yaml-rust 0.4.5 (git+https://github.com/dchakrav-github/yaml-rust)",
 ]
 
 [[package]]
@@ -193,6 +194,101 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+
+[[package]]
+name = "futures-task"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
+name = "futures-util"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -313,12 +409,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +501,18 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
@@ -522,6 +624,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "rstest"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c9dc66cc29792b663ffb5269be669f1613664e69ad56441fdb895c2347b930"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +677,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -576,14 +718,15 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
 dependencies = [
  "indexmap",
+ "itoa",
  "ryu",
  "serde",
- "yaml-rust 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -597,6 +740,15 @@ dependencies = [
  "log",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -701,6 +853,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ee9362deb4a96cef4d437d1ad49cffc9b9e92d202b6995674e928ce684f112"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
+
+[[package]]
 name = "urlencoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,20 +960,3 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "git+https://github.com/dchakrav-github/yaml-rust#1c6497b66caafc34c028d8ef68119d498590c8f1"
-dependencies = [
- "linked-hash-map",
-]

--- a/packages/cfn_guard_rs/Cargo.toml
+++ b/packages/cfn_guard_rs/Cargo.toml
@@ -13,4 +13,4 @@ python-source = "python"
 
 [dependencies]
 pyo3 = { version = "0.16.5", features = ["extension-module"] }
-cfn-guard = { git = "https://github.com/aws-cloudformation/cloudformation-guard", tag = "2.1.0" }
+cfn-guard = { git = "https://github.com/aws-cloudformation/cloudformation-guard", branch = "main" }

--- a/packages/cfn_guard_rs/mypy.ini
+++ b/packages/cfn_guard_rs/mypy.ini
@@ -10,3 +10,6 @@ ignore_missing_imports = True
 
 [mypy-cfn_guard_rs.*]
 ignore_missing_imports = True
+
+[mypy-importlib_metadata.*]
+ignore_missing_imports = True

--- a/packages/cfn_guard_rs/python/cfn_guard_rs/__init__.py
+++ b/packages/cfn_guard_rs/python/cfn_guard_rs/__init__.py
@@ -6,12 +6,10 @@
   to validate a payload using a string version of the rules
 """
 
-from .api import (
-  run_checks
-)
+from .api import run_checks
 
 from .interface import (
-  DataOutput,
-  Comparison,
-  NameInfo,
+    DataOutput,
+    Comparison,
+    NameInfo,
 )

--- a/packages/cfn_guard_rs/python/cfn_guard_rs/api.py
+++ b/packages/cfn_guard_rs/python/cfn_guard_rs/api.py
@@ -31,7 +31,12 @@ def run_checks(data: dict, rules: str) -> DataOutput:
         DataOutput representation of the result of running guard
     """
     # hard code the verbose value.  This will change the output to be a list
-    output = json.loads(run_checks_rs(json.dumps(data), rules, False))
+    guard_output = run_checks_rs(json.dumps(data), rules, False)
+    try:
+        output = json.loads(run_checks_rs(json.dumps(data), rules, False))
+    except json.JSONDecodeError:
+        output = guard_output
+
     # remove the lib set items and replace with our defaults
     result = DataOutput(**output)
 

--- a/packages/cfn_guard_rs/python/cfn_guard_rs/errors.py
+++ b/packages/cfn_guard_rs/python/cfn_guard_rs/errors.py
@@ -1,0 +1,25 @@
+"""
+  Defines the errors that are returned from Guard
+"""
+
+
+# pylint: disable=no-name-in-module,unused-import
+from .cfn_guard_rs import (
+    JsonError,
+    YamlError,
+    FormatError,
+    IoError,
+    ParseError,
+    RegexError,
+    MissingProperty,
+    MissingVariable,
+    MultipleValues,
+    IncompatibleRetrievalError,
+    IncompatibleError,
+    NotComparable,
+    ConversionError,
+    Errors,
+    RetrievalError,
+    MissingValue,
+    FileNotFoundError as GuardFileNotFoundError,  # rename for redefined-builtin
+)

--- a/packages/cfn_guard_rs/python/tests/fixtures/rules/invalid_format.guard
+++ b/packages/cfn_guard_rs/python/tests/fixtures/rules/invalid_format.guard
@@ -1,0 +1,5 @@
+AWS::S3::Bucket {
+    Properties 
+        BucketName is_string
+    }
+}

--- a/packages/cfn_guard_rs/python/tests/fixtures/rules/invalid_missing_value.guard
+++ b/packages/cfn_guard_rs/python/tests/fixtures/rules/invalid_missing_value.guard
@@ -1,0 +1,11 @@
+let ecs_task_definition_task_role_arn = 'arn:aws:iam::123456789012:role/my-task-role-name'
+
+rule check_ecs_task_definition_task_role_arn
+{
+    Resources.*.Properties.TaskRoleArn == %ecs_task_definition_task_role_arn
+}
+
+rule check_ecs_task_definition_execution_role_arn
+{
+    Resources.*.Properties.ExecutionRoleArn == %ecs_task_definition_execution_role_arn
+}

--- a/packages/cfn_guard_rs/python/tests/test_cfn_guard_rs.py
+++ b/packages/cfn_guard_rs/python/tests/test_cfn_guard_rs.py
@@ -3,6 +3,7 @@
 """
 import yaml
 import pytest
+import cfn_guard_rs.errors
 from cfn_guard_rs import Comparison, run_checks, DataOutput, NameInfo
 
 
@@ -66,7 +67,7 @@ from cfn_guard_rs import Comparison, run_checks, DataOutput, NameInfo
                     "S3_BUCKET_LEVEL_PUBLIC_ACCESS_PROHIBITED": [
                         NameInfo(
                             rule="S3_BUCKET_LEVEL_PUBLIC_ACCESS_PROHIBITED",
-                            #pylint: disable=line-too-long
+                            # pylint: disable=line-too-long
                             path="/Resources/Bucket/Properties/PublicAccessBlockConfiguration/BlockPublicAcls",
                             provided="false",
                             expected="true",
@@ -86,10 +87,36 @@ from cfn_guard_rs import Comparison, run_checks, DataOutput, NameInfo
 )
 def test_run_checks(template, rules, expected):
     """Test transactions against run_checks"""
-    with open(template, encoding='utf8') as file:
+    with open(template, encoding="utf8") as file:
         template_str = yaml.safe_load(file)
-    with open(rules, encoding='utf8') as file:
+    with open(rules, encoding="utf8") as file:
         rules = file.read()
 
     result = run_checks(template_str, rules)
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "template,rules,error",
+    [
+        (
+            "python/tests/fixtures/templates/s3_bucket_public_access_valid.yaml",
+            "python/tests/fixtures/rules/invalid_missing_value.guard",
+            cfn_guard_rs.errors.MissingValue,
+        ),
+        (
+            "python/tests/fixtures/templates/s3_bucket_public_access_valid.yaml",
+            "python/tests/fixtures/rules/invalid_format.guard",
+            cfn_guard_rs.errors.ParseError,
+        ),
+    ],
+)
+def test_run_checks_errors(template, rules, error):
+    """Test transactions against run_checks"""
+    with open(template, encoding="utf8") as file:
+        template_str = yaml.safe_load(file)
+    with open(rules, encoding="utf8") as file:
+        rules = file.read()
+
+    with pytest.raises(error):
+        run_checks(template_str, rules)

--- a/packages/cfn_guard_rs/src/errors.rs
+++ b/packages/cfn_guard_rs/src/errors.rs
@@ -1,0 +1,55 @@
+use pyo3::PyErr;
+use pyo3::create_exception;
+use pyo3::exceptions::PyException;
+use cfn_guard::{Error, ErrorKind};
+
+create_exception!(cfn_guard_rs, JsonError, PyException);
+create_exception!(cfn_guard_rs, YamlError, PyException);
+create_exception!(cfn_guard_rs, FormatError, PyException);
+create_exception!(cfn_guard_rs, IoError, PyException);
+create_exception!(cfn_guard_rs, ParseError, PyException);
+create_exception!(cfn_guard_rs, RegexError, PyException);
+create_exception!(cfn_guard_rs, MissingProperty, PyException);
+create_exception!(cfn_guard_rs, MissingVariable, PyException);
+create_exception!(cfn_guard_rs, MultipleValues, PyException);
+create_exception!(cfn_guard_rs, IncompatibleRetrievalError, PyException);
+create_exception!(cfn_guard_rs, IncompatibleError, PyException);
+create_exception!(cfn_guard_rs, NotComparable, PyException);
+create_exception!(cfn_guard_rs, ConversionError, PyException);
+create_exception!(cfn_guard_rs, Errors, PyException);
+create_exception!(cfn_guard_rs, RetrievalError, PyException);
+create_exception!(cfn_guard_rs, MissingValue, PyException);
+create_exception!(cfn_guard_rs, FileNotFoundError, PyException);
+
+pub struct CfnGuardError(pub Error);
+
+impl From<Error> for CfnGuardError {
+    fn from(err: Error) -> Self {
+        Self(err)
+    }
+}
+
+impl From<CfnGuardError> for PyErr {
+    fn from(err: CfnGuardError) -> Self {
+        let e = &err.0;
+        match &e.0 {
+            ErrorKind::JsonError(err) => JsonError::new_err(format!("{}", err)),
+            ErrorKind::YamlError(err) => YamlError::new_err(format!("{}", err)),
+            ErrorKind::FormatError(err) => FormatError::new_err(format!("{}", err)),
+            ErrorKind::IoError(err) => IoError::new_err(format!("{}", err)),
+            ErrorKind::ParseError(err) => ParseError::new_err(format!("{}", err)),
+            ErrorKind::RegexError(err) => RegexError::new_err(format!("{}", err)),
+            ErrorKind::MissingProperty(err) => MissingProperty::new_err(format!("{}", err)),
+            ErrorKind::MissingVariable(err) => MissingVariable::new_err(format!("{}", err)),
+            ErrorKind::MultipleValues(err) => MultipleValues::new_err(format!("{}", err)),
+            ErrorKind::IncompatibleRetrievalError(err) => IncompatibleRetrievalError::new_err(format!("{}", err)),
+            ErrorKind::IncompatibleError(err) => IncompatibleError::new_err(format!("{}", err)),
+            ErrorKind::NotComparable(err) => NotComparable::new_err(format!("{}", err)),
+            ErrorKind::ConversionError(err) => ConversionError::new_err(format!("{}", err)),
+            ErrorKind::Errors(_err) => Errors::new_err("multiple errors"),
+            ErrorKind::RetrievalError(err) => RetrievalError::new_err(format!("{}", err)),
+            ErrorKind::MissingValue(err) => MissingValue::new_err(format!("{}", err)),
+            ErrorKind::FileNotFoundError(err) => FileNotFoundError::new_err(format!("{}", err)),
+        }
+    }
+}

--- a/packages/cfn_guard_rs/src/lib.rs
+++ b/packages/cfn_guard_rs/src/lib.rs
@@ -1,20 +1,34 @@
 use pyo3::prelude::*;
-use cfn_guard;
+use cfn_guard::{run_checks, ValidateInput};
+mod errors;
 
 /// Formats the sum of two numbers as string.
 #[pyfunction]
-fn run_checks_rs(data: &str, rules: &str, verbose: bool) -> PyResult<String> {
-    let result = match cfn_guard::run_checks(data, rules, verbose)
-    {
-        Ok(t) => t,
-        Err(e) => (e.to_string()),
-    };
+fn run_checks_rs(data: &str, rules: &str, verbose: bool) -> Result<String, errors::CfnGuardError> {
+    let result = run_checks(ValidateInput { content: data, file_name: ""}, ValidateInput { content: rules, file_name: ""}, verbose)?;
     Ok(result)
 }
 
 /// A Python module implemented in Rust.
 #[pymodule]
 fn cfn_guard_rs(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add("JsonError", _py.get_type::<errors::JsonError>())?;
+    m.add("YamlError", _py.get_type::<errors::YamlError>())?;
+    m.add("FormatError", _py.get_type::<errors::FormatError>())?;
+    m.add("IoError", _py.get_type::<errors::IoError>())?;
+    m.add("RegexError", _py.get_type::<errors::RegexError>())?;
+    m.add("ParseError", _py.get_type::<errors::ParseError>())?;
+    m.add("MissingProperty", _py.get_type::<errors::MissingProperty>())?;
+    m.add("MissingVariable", _py.get_type::<errors::MissingVariable>())?;
+    m.add("MultipleValues", _py.get_type::<errors::MultipleValues>())?;
+    m.add("IncompatibleRetrievalError", _py.get_type::<errors::IncompatibleRetrievalError>())?;
+    m.add("IncompatibleError", _py.get_type::<errors::IncompatibleError>())?;
+    m.add("NotComparable", _py.get_type::<errors::NotComparable>())?;
+    m.add("ConversionError", _py.get_type::<errors::ConversionError>())?;
+    m.add("Errors", _py.get_type::<errors::Errors>())?;
+    m.add("RetrievalError", _py.get_type::<errors::RetrievalError>())?;
+    m.add("MissingValue", _py.get_type::<errors::MissingValue>())?;
+    m.add("FileNotFoundError", _py.get_type::<errors::FileNotFoundError>())?;
     m.add_function(wrap_pyfunction!(run_checks_rs, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
*Issue #, if available:*
#60
*Description of changes:*
- Instead of turning errors into strings return them as python errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
