### PR TITLE
fix(cfn-guard-rs) - Apply more specific error types to guard errors

### DIFF
--- a/packages/cfn_guard_rs/python/cfn_guard_rs/api.py
+++ b/packages/cfn_guard_rs/python/cfn_guard_rs/api.py
@@ -40,15 +40,26 @@ def run_checks(data: dict, rules: str) -> DataOutput:
     """
     try:
         output = json.loads(run_checks_rs(json.dumps(data), rules, False))
+
+        # remove the lib set items and replace with our defaults
+        result = DataOutput(**output)
+
+        return result
     except json.JSONDecodeError as err:
-        LOG.debug("JSON decoding error when processing return value [%s] got error: %s", output, err)
+        LOG.debug(
+            "JSON decoding error when processing return value [%s] got error: %s",
+            output,
+            err,
+        )
         raise err
     except CfnGuardMissingValue as err:
         raise errors.MissingValue() from err
     except CfnGuardParseError as err:
         raise errors.ParseError() from err
-
-    # remove the lib set items and replace with our defaults
-    result = DataOutput(**output)
-
-    return result
+    except Exception as err:
+        LOG.debug(
+            "Received unknown exception [%s] while running checks, got error: %s",
+            type(err),
+            err,
+        )
+        raise errors.UnknownError() from err

--- a/packages/cfn_guard_rs/python/cfn_guard_rs/errors.py
+++ b/packages/cfn_guard_rs/python/cfn_guard_rs/errors.py
@@ -3,23 +3,13 @@
 """
 
 
-# pylint: disable=no-name-in-module,unused-import
-from .cfn_guard_rs import (
-    JsonError,
-    YamlError,
-    FormatError,
-    IoError,
-    ParseError,
-    RegexError,
-    MissingProperty,
-    MissingVariable,
-    MultipleValues,
-    IncompatibleRetrievalError,
-    IncompatibleError,
-    NotComparable,
-    ConversionError,
-    Errors,
-    RetrievalError,
-    MissingValue,
-    FileNotFoundError as GuardFileNotFoundError,  # rename for redefined-builtin
-)
+class GuardError(BaseException):
+    """General exception to cover all Guard exceptions"""
+
+
+class ParseError(GuardError, ValueError):
+    """Raised when having an issue parsing rules"""
+
+
+class MissingValue(ParseError, NameError):
+    """There was no variable or value object to resolve"""

--- a/packages/cfn_guard_rs/python/cfn_guard_rs/errors.py
+++ b/packages/cfn_guard_rs/python/cfn_guard_rs/errors.py
@@ -7,6 +7,10 @@ class GuardError(BaseException):
     """General exception to cover all Guard exceptions"""
 
 
+class UnknownError(GuardError):
+    """Raised when having an unknown error is encountered"""
+
+
 class ParseError(GuardError, ValueError):
     """Raised when having an issue parsing rules"""
 

--- a/packages/cfn_guard_rs/python/tests/test_cfn_guard_rs.py
+++ b/packages/cfn_guard_rs/python/tests/test_cfn_guard_rs.py
@@ -1,6 +1,7 @@
 """
     Test cfn_guard_rs
 """
+from unittest.mock import patch
 import yaml
 import pytest
 import cfn_guard_rs.errors
@@ -128,3 +129,19 @@ def test_run_checks_errors(template, rules, error, parent_error):
 
     with pytest.raises(cfn_guard_rs.errors.GuardError):
         run_checks(template_str, rules)
+
+
+def test_run_unknown_errors():
+    """Test unknown errors"""
+
+    template_filename = "python/tests/fixtures/templates/s3_bucket_name_valid.yaml"
+    rules_filename = "python/tests/fixtures/rules/s3_bucket_name.guard"
+    with open(template_filename, encoding="utf8") as file:
+        template_str = yaml.safe_load(file)
+    with open(rules_filename, encoding="utf8") as file:
+        rules = file.read()
+
+    with patch("json.loads") as mock_method:
+        mock_method.side_effect = Exception("test")
+        with pytest.raises(cfn_guard_rs.errors.UnknownError):
+            run_checks(template_str, rules)

--- a/packages/cfn_guard_rs/python/tests/test_cfn_guard_rs.py
+++ b/packages/cfn_guard_rs/python/tests/test_cfn_guard_rs.py
@@ -125,3 +125,6 @@ def test_run_checks_errors(template, rules, error, parent_error):
 
     with pytest.raises(parent_error):
         run_checks(template_str, rules)
+
+    with pytest.raises(cfn_guard_rs.errors.GuardError):
+        run_checks(template_str, rules)

--- a/packages/cfn_guard_rs/python/tests/test_cfn_guard_rs.py
+++ b/packages/cfn_guard_rs/python/tests/test_cfn_guard_rs.py
@@ -97,21 +97,23 @@ def test_run_checks(template, rules, expected):
 
 
 @pytest.mark.parametrize(
-    "template,rules,error",
+    "template,rules,error,parent_error",
     [
         (
             "python/tests/fixtures/templates/s3_bucket_public_access_valid.yaml",
             "python/tests/fixtures/rules/invalid_missing_value.guard",
             cfn_guard_rs.errors.MissingValue,
+            NameError,
         ),
         (
             "python/tests/fixtures/templates/s3_bucket_public_access_valid.yaml",
             "python/tests/fixtures/rules/invalid_format.guard",
             cfn_guard_rs.errors.ParseError,
+            ValueError,
         ),
     ],
 )
-def test_run_checks_errors(template, rules, error):
+def test_run_checks_errors(template, rules, error, parent_error):
     """Test transactions against run_checks"""
     with open(template, encoding="utf8") as file:
         template_str = yaml.safe_load(file)
@@ -119,4 +121,7 @@ def test_run_checks_errors(template, rules, error):
         rules = file.read()
 
     with pytest.raises(error):
+        run_checks(template_str, rules)
+
+    with pytest.raises(parent_error):
         run_checks(template_str, rules)

--- a/packages/cfn_guard_rs/src/errors.rs
+++ b/packages/cfn_guard_rs/src/errors.rs
@@ -9,35 +9,30 @@ use cfn_guard::{Error, ErrorKind};
 import_exception!(json, JSONDecodeError);
 import_exception!(yaml, YAMLError);
 
-create_exception!(cfn_guard_rs, JsonError, JSONDecodeError);
-create_exception!(cfn_guard_rs, YamlError, YAMLError);
-// Standard IO Error
-create_exception!(cfn_guard_rs, IoError, exceptions::PyIOError);
-// ParseError is used a lot
-create_exception!(cfn_guard_rs, ParseError, exceptions::PyValueError);
-// When a variable isn't found in the in the rule
-create_exception!(cfn_guard_rs, MissingVariable, exceptions::PyAttributeError);
-// Key already exists in map
-create_exception!(cfn_guard_rs, MultipleValues, exceptions::PyValueError);
-// Used in lots of locations. Type or variable has incompatible types
-create_exception!(cfn_guard_rs, IncompatibleRetrievalError, exceptions::PyTypeError);
-// Used in lots of locations. Types or variable assignments are incompatible
-create_exception!(cfn_guard_rs, IncompatibleError, exceptions::PyTypeError);
-// Used in lots of locations. Comparing incoming context with literals or dynamic results wasn't possible
-create_exception!(cfn_guard_rs, NotComparable, exceptions::PyTypeError);
-// Used in lots of locations. Could not retrieve data from incoming context.
-create_exception!(cfn_guard_rs, RetrievalError, exceptions::PyException);
-// There was no variable or value object to resolve.
-create_exception!(cfn_guard_rs, MissingValue, exceptions::PyNameError);
-// Standard FileNotFoundError
-create_exception!(cfn_guard_rs, FileNotFoundError, exceptions::PyFileNotFoundError);
+create_exception!(cfn_guard_rs, CfnGuardJsonError, JSONDecodeError);
+create_exception!(cfn_guard_rs, CfnGuardYamlError, YAMLError);
+create_exception!(cfn_guard_rs, CfnGuardIoError, exceptions::PyIOError);
+create_exception!(cfn_guard_rs, CfnGuardFileNotFoundError, exceptions::PyFileNotFoundError);
+
+// ParseError
+create_exception!(cfn_guard_rs, CfnGuardParseError, exceptions::PyValueError);
+// Value cannot be resolved
+create_exception!(cfn_guard_rs, CfnGuardMissingValue, exceptions::PyNameError);
+
+// Captured by rule evaluations
+create_exception!(cfn_guard_rs, CfnGuardMissingVariable, exceptions::PyAttributeError);
+create_exception!(cfn_guard_rs, CfnGuardMultipleValues, exceptions::PyValueError);
+create_exception!(cfn_guard_rs, CfnGuardIncompatibleRetrievalError, exceptions::PyTypeError);
+create_exception!(cfn_guard_rs, CfnGuardIncompatibleError, exceptions::PyTypeError);
+create_exception!(cfn_guard_rs, CfnGuardNotComparable, exceptions::PyTypeError);
+create_exception!(cfn_guard_rs, CfnGuardRetrievalError, exceptions::PyException);
 
 // Can't find where these errors are actually used
-create_exception!(cfn_guard_rs, FormatError, exceptions::PyException);
-create_exception!(cfn_guard_rs, RegexError, exceptions::PyException);
-create_exception!(cfn_guard_rs, MissingProperty, exceptions::PyException);
-create_exception!(cfn_guard_rs, ConversionError, exceptions::PyException);
-create_exception!(cfn_guard_rs, Errors, exceptions::PyException);
+create_exception!(cfn_guard_rs, CfnGuardFormatError, exceptions::PyException);
+create_exception!(cfn_guard_rs, CfnGuardRegexError, exceptions::PyException);
+create_exception!(cfn_guard_rs, CfnGuardMissingProperty, exceptions::PyException);
+create_exception!(cfn_guard_rs, CfnGuardConversionError, exceptions::PyException);
+create_exception!(cfn_guard_rs, CfnGuardErrors, exceptions::PyException);
 
 pub struct CfnGuardError(pub Error);
 
@@ -51,23 +46,23 @@ impl From<CfnGuardError> for PyErr {
     fn from(err: CfnGuardError) -> Self {
         let e = &err.0;
         match &e.0 {
-            ErrorKind::JsonError(err) => JsonError::new_err(format!("{}", err)),
-            ErrorKind::YamlError(err) => YamlError::new_err(format!("{}", err)),
-            ErrorKind::FormatError(err) => FormatError::new_err(format!("{}", err)),
-            ErrorKind::IoError(err) => IoError::new_err(format!("{}", err)),
-            ErrorKind::ParseError(err) => ParseError::new_err(format!("{}", err)),
-            ErrorKind::RegexError(err) => RegexError::new_err(format!("{}", err)),
-            ErrorKind::MissingProperty(err) => MissingProperty::new_err(format!("{}", err)),
-            ErrorKind::MissingVariable(err) => MissingVariable::new_err(format!("{}", err)),
-            ErrorKind::MultipleValues(err) => MultipleValues::new_err(format!("{}", err)),
-            ErrorKind::IncompatibleRetrievalError(err) => IncompatibleRetrievalError::new_err(format!("{}", err)),
-            ErrorKind::IncompatibleError(err) => IncompatibleError::new_err(format!("{}", err)),
-            ErrorKind::NotComparable(err) => NotComparable::new_err(format!("{}", err)),
-            ErrorKind::ConversionError(err) => ConversionError::new_err(format!("{}", err)),
-            ErrorKind::Errors(_err) => Errors::new_err("multiple errors"),
-            ErrorKind::RetrievalError(err) => RetrievalError::new_err(format!("{}", err)),
-            ErrorKind::MissingValue(err) => MissingValue::new_err(format!("{}", err)),
-            ErrorKind::FileNotFoundError(err) => FileNotFoundError::new_err(format!("{}", err)),
+            ErrorKind::JsonError(err) => CfnGuardJsonError::new_err(format!("{}", err)),
+            ErrorKind::YamlError(err) => CfnGuardYamlError::new_err(format!("{}", err)),
+            ErrorKind::FormatError(err) => CfnGuardFormatError::new_err(format!("{}", err)),
+            ErrorKind::IoError(err) => CfnGuardIoError::new_err(format!("{}", err)),
+            ErrorKind::ParseError(err) => CfnGuardParseError::new_err(format!("{}", err)),
+            ErrorKind::RegexError(err) => CfnGuardRegexError::new_err(format!("{}", err)),
+            ErrorKind::MissingProperty(err) => CfnGuardMissingProperty::new_err(format!("{}", err)),
+            ErrorKind::MissingVariable(err) => CfnGuardMissingVariable::new_err(format!("{}", err)),
+            ErrorKind::MultipleValues(err) => CfnGuardMultipleValues::new_err(format!("{}", err)),
+            ErrorKind::IncompatibleRetrievalError(err) => CfnGuardIncompatibleRetrievalError::new_err(format!("{}", err)),
+            ErrorKind::IncompatibleError(err) => CfnGuardIncompatibleError::new_err(format!("{}", err)),
+            ErrorKind::NotComparable(err) => CfnGuardNotComparable::new_err(format!("{}", err)),
+            ErrorKind::ConversionError(err) => CfnGuardConversionError::new_err(format!("{}", err)),
+            ErrorKind::Errors(_err) => CfnGuardErrors::new_err("multiple errors"),
+            ErrorKind::RetrievalError(err) => CfnGuardRetrievalError::new_err(format!("{}", err)),
+            ErrorKind::MissingValue(err) => CfnGuardMissingValue::new_err(format!("{}", err)),
+            ErrorKind::FileNotFoundError(err) => CfnGuardFileNotFoundError::new_err(format!("{}", err)),
         }
     }
 }

--- a/packages/cfn_guard_rs/src/errors.rs
+++ b/packages/cfn_guard_rs/src/errors.rs
@@ -1,25 +1,43 @@
-use pyo3::PyErr;
-use pyo3::create_exception;
-use pyo3::exceptions::PyException;
+use pyo3::{
+    PyErr,
+    create_exception,
+    import_exception,
+    exceptions,
+};
 use cfn_guard::{Error, ErrorKind};
 
-create_exception!(cfn_guard_rs, JsonError, PyException);
-create_exception!(cfn_guard_rs, YamlError, PyException);
-create_exception!(cfn_guard_rs, FormatError, PyException);
-create_exception!(cfn_guard_rs, IoError, PyException);
-create_exception!(cfn_guard_rs, ParseError, PyException);
-create_exception!(cfn_guard_rs, RegexError, PyException);
-create_exception!(cfn_guard_rs, MissingProperty, PyException);
-create_exception!(cfn_guard_rs, MissingVariable, PyException);
-create_exception!(cfn_guard_rs, MultipleValues, PyException);
-create_exception!(cfn_guard_rs, IncompatibleRetrievalError, PyException);
-create_exception!(cfn_guard_rs, IncompatibleError, PyException);
-create_exception!(cfn_guard_rs, NotComparable, PyException);
-create_exception!(cfn_guard_rs, ConversionError, PyException);
-create_exception!(cfn_guard_rs, Errors, PyException);
-create_exception!(cfn_guard_rs, RetrievalError, PyException);
-create_exception!(cfn_guard_rs, MissingValue, PyException);
-create_exception!(cfn_guard_rs, FileNotFoundError, PyException);
+import_exception!(json, JSONDecodeError);
+import_exception!(yaml, YAMLError);
+
+create_exception!(cfn_guard_rs, JsonError, JSONDecodeError);
+create_exception!(cfn_guard_rs, YamlError, YAMLError);
+// Standard IO Error
+create_exception!(cfn_guard_rs, IoError, exceptions::PyIOError);
+// ParseError is used a lot
+create_exception!(cfn_guard_rs, ParseError, exceptions::PyValueError);
+// When a variable isn't found in the in the rule
+create_exception!(cfn_guard_rs, MissingVariable, exceptions::PyAttributeError);
+// Key already exists in map
+create_exception!(cfn_guard_rs, MultipleValues, exceptions::PyValueError);
+// Used in lots of locations. Type or variable has incompatible types
+create_exception!(cfn_guard_rs, IncompatibleRetrievalError, exceptions::PyTypeError);
+// Used in lots of locations. Types or variable assignments are incompatible
+create_exception!(cfn_guard_rs, IncompatibleError, exceptions::PyTypeError);
+// Used in lots of locations. Comparing incoming context with literals or dynamic results wasn't possible
+create_exception!(cfn_guard_rs, NotComparable, exceptions::PyTypeError);
+// Used in lots of locations. Could not retrieve data from incoming context.
+create_exception!(cfn_guard_rs, RetrievalError, exceptions::PyException);
+// There was no variable or value object to resolve.
+create_exception!(cfn_guard_rs, MissingValue, exceptions::PyNameError);
+// Standard FileNotFoundError
+create_exception!(cfn_guard_rs, FileNotFoundError, exceptions::PyFileNotFoundError);
+
+// Can't find where these errors are actually used
+create_exception!(cfn_guard_rs, FormatError, exceptions::PyException);
+create_exception!(cfn_guard_rs, RegexError, exceptions::PyException);
+create_exception!(cfn_guard_rs, MissingProperty, exceptions::PyException);
+create_exception!(cfn_guard_rs, ConversionError, exceptions::PyException);
+create_exception!(cfn_guard_rs, Errors, exceptions::PyException);
 
 pub struct CfnGuardError(pub Error);
 

--- a/packages/cfn_guard_rs/src/lib.rs
+++ b/packages/cfn_guard_rs/src/lib.rs
@@ -12,23 +12,31 @@ fn run_checks_rs(data: &str, rules: &str, verbose: bool) -> Result<String, error
 /// A Python module implemented in Rust.
 #[pymodule]
 fn cfn_guard_rs(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add("JsonError", _py.get_type::<errors::JsonError>())?;
-    m.add("YamlError", _py.get_type::<errors::YamlError>())?;
-    m.add("FormatError", _py.get_type::<errors::FormatError>())?;
-    m.add("IoError", _py.get_type::<errors::IoError>())?;
-    m.add("RegexError", _py.get_type::<errors::RegexError>())?;
-    m.add("ParseError", _py.get_type::<errors::ParseError>())?;
-    m.add("MissingProperty", _py.get_type::<errors::MissingProperty>())?;
-    m.add("MissingVariable", _py.get_type::<errors::MissingVariable>())?;
-    m.add("MultipleValues", _py.get_type::<errors::MultipleValues>())?;
-    m.add("IncompatibleRetrievalError", _py.get_type::<errors::IncompatibleRetrievalError>())?;
-    m.add("IncompatibleError", _py.get_type::<errors::IncompatibleError>())?;
-    m.add("NotComparable", _py.get_type::<errors::NotComparable>())?;
-    m.add("ConversionError", _py.get_type::<errors::ConversionError>())?;
-    m.add("Errors", _py.get_type::<errors::Errors>())?;
-    m.add("RetrievalError", _py.get_type::<errors::RetrievalError>())?;
-    m.add("MissingValue", _py.get_type::<errors::MissingValue>())?;
-    m.add("FileNotFoundError", _py.get_type::<errors::FileNotFoundError>())?;
+    // cfn-guard-rs currently doesn't allow for parsing files
+    m.add("_CfnGuardJsonError", _py.get_type::<errors::CfnGuardJsonError>())?;
+    m.add("_CfnGuardYamlError", _py.get_type::<errors::CfnGuardYamlError>())?;
+    m.add("_CfnGuardIoError", _py.get_type::<errors::CfnGuardIoError>())?;
+    m.add("_CfnGuardFileNotFoundError", _py.get_type::<errors::CfnGuardFileNotFoundError>())?;
+
+    // unused errors
+    m.add("_CfnGuardFormatError", _py.get_type::<errors::CfnGuardFormatError>())?;
+    m.add("_CfnGuardRegexError", _py.get_type::<errors::CfnGuardRegexError>())?;
+    m.add("_CfnGuardMissingProperty", _py.get_type::<errors::CfnGuardMissingProperty>())?;
+    m.add("_CfnGuardConversionError", _py.get_type::<errors::CfnGuardConversionError>())?;
+    m.add("_CfnGuardErrors", _py.get_type::<errors::CfnGuardErrors>())?;
+    
+    // masked and captured by rule processing
+    m.add("_CfnGuardMultipleValues", _py.get_type::<errors::CfnGuardMultipleValues>())?;
+    m.add("_CfnGuardIncompatibleRetrievalError", _py.get_type::<errors::CfnGuardIncompatibleRetrievalError>())?;
+    m.add("_CfnGuardIncompatibleError", _py.get_type::<errors::CfnGuardIncompatibleError>())?;
+    m.add("_CfnGuardNotComparable", _py.get_type::<errors::CfnGuardNotComparable>())?;
+    m.add("_CfnGuardRetrievalError", _py.get_type::<errors::CfnGuardRetrievalError>())?;
+    m.add("_CfnGuardMissingVariable", _py.get_type::<errors::CfnGuardMissingVariable>())?;
+
+    // Exceptions that may get passed back
+    m.add("CfnGuardParseError", _py.get_type::<errors::CfnGuardParseError>())?;
+    m.add("CfnGuardMissingValue", _py.get_type::<errors::CfnGuardMissingValue>())?;
+    
     m.add_function(wrap_pyfunction!(run_checks_rs, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Use more specific error types for guard errors

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
