### PR TITLE
chore(release) - update CI/CD templates and publish package trigger

### DIFF
--- a/.github/workflows/packages-cfn_guard_rs-CD.yml
+++ b/.github/workflows/packages-cfn_guard_rs-CD.yml
@@ -1,83 +1,66 @@
 name: packages-cfn_guard_rs-CD
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "packages/cfn_guard_rs/**"
-      - "packages/cfn_guard_rs_hook/**"
-  pull_request:
-    paths:
-      - "packages/cfn_guard_rs/**"
-      - "packages/cfn_guard_rs_hook/**"
+  release:
+    types: [published]
 jobs:
   linux:
     strategy:
       matrix:
         target: [aarch64, x86_64]
-        directory:
-          - ./packages/cfn_guard_rs
-          - ./packages/cfn_guard_rs_hook
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ matrix.directory }}
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v1
+      - uses: messense/maturin-action@v1
         with:
-          python-version: "3.7"
-      - name: Install Tox and any other packages
-        run: pip3 install tox
-      - name: Run Tox
-        run: |
-          python3 --version
-          tox -e py
+          manylinux: auto
+          command: build
+          target: ${{ matrix.target }}
+          args: --release -m packages/cfn_guard_rs/Cargo.toml --sdist -o packages/cfn_guard_rs/dist --find-interpreter
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: packages/cfn_guard_rs/dist
 
   windows:
-    strategy:
-      matrix:
-        directory:
-          - ./packages/cfn_guard_rs
-          - ./packages/cfn_guard_rs_hook
     runs-on: windows-latest
-    defaults:
-      run:
-        working-directory: ${{ matrix.directory }}
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v1
+      - uses: messense/maturin-action@v1
         with:
-          python-version: "3.7"
-      - name: Install Tox and any other packages
-        run: pip3 install tox
-      - name: Run Tox
-        run: |
-          python3 --version
-          tox -e py
+          command: build
+          args: --release -m packages/cfn_guard_rs/Cargo.toml -o packages/cfn_guard_rs/dist --find-interpreter
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: packages/cfn_guard_rs/dist
 
   macos:
-    strategy:
-      matrix:
-        directory:
-          - ./packages/cfn_guard_rs
-          - ./packages/cfn_guard_rs_hook
     runs-on: macos-latest
-    defaults:
-      run:
-        working-directory: ${{ matrix.directory }}
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v1
+      - uses: messense/maturin-action@v1
         with:
-          python-version: "3.7"
-      - name: Install Tox and any other packages
-        run: pip3 install tox
-      - name: Run Tox
-        run: |
-          python3 --version
-          tox -e py
+          command: build
+          args: --release -m packages/cfn_guard_rs/Cargo.toml -o packages/cfn_guard_rs/dist --universal2 --find-interpreter
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: packages/cfn_guard_rs/dist
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/cfn-guard-rs-v')"
+    needs: [macos, windows, linux]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheels
+      - name: Publish to PyPI
+        uses: messense/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          command: upload
+          args: --skip-existing *

--- a/.github/workflows/packages-cfn_guard_rs-CD.yml
+++ b/.github/workflows/packages-cfn_guard_rs-CD.yml
@@ -1,8 +1,9 @@
 name: packages-cfn_guard_rs-CD
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:        
+      - cfn-guard-rs-v*
 jobs:
   linux:
     strategy:
@@ -51,7 +52,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/cfn-guard-rs-v')"
     needs: [macos, windows, linux]
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/packages-cfn_guard_rs-CI.yml
+++ b/.github/workflows/packages-cfn_guard_rs-CI.yml
@@ -6,64 +6,78 @@ on:
       - main
     paths:
       - "packages/cfn_guard_rs/**"
+      - "packages/cfn_guard_rs_hook/**"
+  pull_request:
+    paths:
+      - "packages/cfn_guard_rs/**"
+      - "packages/cfn_guard_rs_hook/**"
 jobs:
   linux:
     strategy:
       matrix:
         target: [aarch64, x86_64]
+        directory:
+          - ./packages/cfn_guard_rs
+          - ./packages/cfn_guard_rs_hook
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ matrix.directory }}
     steps:
       - uses: actions/checkout@v3
-      - uses: messense/maturin-action@v1
+      - name: Setup Python
+        uses: actions/setup-python@v1
         with:
-          manylinux: auto
-          command: build
-          target: ${{ matrix.target }}
-          args: --release -m packages/cfn_guard_rs/Cargo.toml --sdist -o packages/cfn_guard_rs/dist --find-interpreter
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: packages/cfn_guard_rs/dist
+          python-version: "3.7"
+      - name: Install Tox and any other packages
+        run: pip3 install tox
+      - name: Run Tox
+        run: |
+          python3 --version
+          tox -e py
 
   windows:
+    strategy:
+      matrix:
+        directory:
+          - ./packages/cfn_guard_rs
+          - ./packages/cfn_guard_rs_hook
     runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: ${{ matrix.directory }}
     steps:
       - uses: actions/checkout@v3
-      - uses: messense/maturin-action@v1
+      - name: Setup Python
+        uses: actions/setup-python@v1
         with:
-          command: build
-          args: --release -m packages/cfn_guard_rs/Cargo.toml -o packages/cfn_guard_rs/dist --find-interpreter
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: packages/cfn_guard_rs/dist
+          python-version: "3.7"
+      - name: Install Tox and any other packages
+        run: pip3 install tox
+      - name: Run Tox
+        run: |
+          python3 --version
+          tox -e py
 
   macos:
+    strategy:
+      matrix:
+        directory:
+          - ./packages/cfn_guard_rs
+          - ./packages/cfn_guard_rs_hook
     runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: ${{ matrix.directory }}
     steps:
       - uses: actions/checkout@v3
-      - uses: messense/maturin-action@v1
+      - name: Setup Python
+        uses: actions/setup-python@v1
         with:
-          command: build
-          args: --release -m packages/cfn_guard_rs/Cargo.toml -o packages/cfn_guard_rs/dist --universal2 --find-interpreter
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: packages/cfn_guard_rs/dist
-
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [macos, windows, linux]
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: wheels
-      - name: Publish to PyPI
-        uses: messense/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        with:
-          command: upload
-          args: --skip-existing *
+          python-version: "3.7"
+      - name: Install Tox and any other packages
+        run: pip3 install tox
+      - name: Run Tox
+        run: |
+          python3 --version
+          tox -e py

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ See the contributer guide: [./CONTRIBUTING.md](CONTRIBUTING.md)
 
 Also check out how our release process works here: [./RELEASE.md](RELEASE.md)
 
+## Publishing packages
+
+We publish our python packages in `packages/` to pypi. When we publish a release a workflow is triggered to do the publishing. See the `CD.yml` workflows [here](./github/workflows)
+
+For `cfn-guard-rs` we tag the release with `cfn-guard-rs-vX.X.X`
+For `cfn-guard-rs-hook` we tag the release with `cfn-guard-rs-hook-vX.X.X`
+
 ## Maintainers
 
 [![](https://github.com/ericzbeard.png?size=50)](https://github.com/ericzbeard)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix accidental wrong names. Renamed the CD template CI and vice versa.
- Switch the CD workflow to trigger on release being published

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
