### PR TITLE
Expain the use of one setup.[yml|json]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,9 +92,9 @@ https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-te
 Rename the `example_inputs` folder to `inputs` and edit the JSON files to
 reflect outputs from the setup stack. You can skip creation of `setup.yml` if your 
 resource does not require any resources to be created beforehand. (One gotcha with the input files: Export variables can't have special characters in them)
+if there are multiple inputs (e.g. `inputs_2_create.json`), you can reuse the same `setup.yml` or `setup.json`. Either reuse the created resources, or create more resources and a different output/export if they need to be independent. 
 
 TODO: Can we change the init templates to just do this stuff by default?
-TODO: What if there are multiple inputs, e.g. `inputs_2_create.json`, will we need `setup2.yml?`
 
 Put a sample template into your `README.md` file to demonstrate usage. Also
 create a template called `test/integ.yml` to be run by the release process to


### PR DESCRIPTION
I picked the option that made the most sense to me, feel free to use this PR as a discussion thread instead.

This assumes there will be no tests run in parallel (for the same resource)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
