### PR TITLE
Add AwsCommunity::Account::AlternateContact

### DIFF
--- a/resources/Account_AlternateContact/.gitignore
+++ b/resources/Account_AlternateContact/.gitignore
@@ -1,0 +1,132 @@
+# cfn cli output file
+*.zip
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# contains credentials
+sam-tests/
+
+rpdk.log*

--- a/resources/Account_AlternateContact/.rpdk-config
+++ b/resources/Account_AlternateContact/.rpdk-config
@@ -1,0 +1,21 @@
+{
+    "artifact_type": "RESOURCE",
+    "typeName": "AwsCommunity::Account::AlternateContact",
+    "language": "python37",
+    "runtime": "python3.7",
+    "entrypoint": "awscommunity_account_alternatecontact.handlers.resource",
+    "testEntrypoint": "awscommunity_account_alternatecontact.handlers.test_entrypoint",
+    "settings": {
+        "version": false,
+        "subparser_name": null,
+        "verbose": 0,
+        "force": false,
+        "type_name": null,
+        "artifact_type": null,
+        "endpoint_url": null,
+        "region": null,
+        "target_schemas": [],
+        "use_docker": true,
+        "protocolVersion": "2.0.0"
+    }
+}

--- a/resources/Account_AlternateContact/README.md
+++ b/resources/Account_AlternateContact/README.md
@@ -1,0 +1,32 @@
+# AwsCommunity::Account::AlternateContact
+
+## Design remarks
+- We always require the account id (even though this is not required by the api) to make a few
+  things easier to implement:
+  - PrimaryIdentifier can always be Account + Contact type
+  - List can work per-account if an Account Id is given (and return an error, all accounts if none
+    is specified)
+- Even so, the list handler is not implemented 
+- The same api / resource can be used in the management and a member account, however the parameters
+  can be slightly different, the resource abstracts that away, using the in-account way when the
+  AccountId matches the account id of the CloudFormation Stack, and using the organizations way in
+  all the other cases. 
+
+## Testing remarks
+When testing against the local account, nothing has to exist - but also there can't be a contact 
+already defined
+
+## Sample template
+```yaml
+Description: Create the Operations Alternate Contact for the current account
+Resources:
+  OperationsContact:
+    Type: AwsCommunity::Account::AlternateContact
+    Properties:
+      AccountId: !Ref "AWS::AccountId"
+      AlternateContactType: OPERATIONS
+      EmailAddress: operations@example.com
+      Name: Operations Distribution List
+      PhoneNumber: +12065550000
+      Title: Ops
+```

--- a/resources/Account_AlternateContact/awscommunity-account-alternatecontact.json
+++ b/resources/Account_AlternateContact/awscommunity-account-alternatecontact.json
@@ -1,0 +1,83 @@
+{
+    "typeName": "AwsCommunity::Account::AlternateContact",
+    "description": "An alternate contact attached to an Amazon Web Services account.",
+    "sourceUrl": "https://github.com/aws-cloudformation/community-registry-extensions.git",
+    "definitions": {
+    },
+    "properties": {
+        "AccountId": {
+            "description": "The account ID of the AWS account that you want to add an alternate contact to. If you do not specify this parameter, it defaults to the current AWS account.",
+            "type": "string",
+            "pattern": "^\\d{12}$"
+        },
+        "AlternateContactType": {
+            "description": "The type of alternate contact you want to create.",
+            "type": "string",
+            "enum": ["BILLING", "OPERATIONS", "SECURITY"]
+        },
+        "EmailAddress": {
+            "description": "The email address for the alternate contact.",
+            "type": "string",
+            "pattern": "^[\\s]*[\\w+=.#!&-]+@[\\w.-]+\\.[\\w]+[\\s]*$"
+        },
+        "Name": {
+            "description": "The name for the alternate contact.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64
+        },
+        "PhoneNumber": {
+            "description": "The phone number for the alternate contact.",
+            "type": "string",
+            "pattern": "^[\\s0-9()+-]{1,25}$"
+        },
+        "Title": {
+            "description": "The title for the alternate contact.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 50
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "AccountId",
+        "AlternateContactType",
+        "EmailAddress",
+        "Name",
+        "PhoneNumber",
+        "Title"
+    ],
+    "createOnlyProperties": [
+        "/properties/AccountId", "/properties/AlternateContactType"
+    ],
+    "primaryIdentifier": [
+        "/properties/AccountId", "/properties/AlternateContactType"
+    ],
+    "tagging": {
+        "taggable": false
+    },
+    "handlers": {
+        "create": {
+            "permissions": [
+                "account:GetAlternateContact",
+                "account:PutAlternateContact"
+            ]
+        },
+        "read": {
+            "permissions": [
+                "account:GetAlternateContact"
+            ]
+        },
+        "update": {
+            "permissions": [
+                "account:GetAlternateContact",
+                "account:PutAlternateContact"
+            ]
+        },
+        "delete": {
+            "permissions": [
+                "account:DeleteAlternateContact"
+            ]
+        }
+    }
+}

--- a/resources/Account_AlternateContact/docs/README.md
+++ b/resources/Account_AlternateContact/docs/README.md
@@ -1,0 +1,115 @@
+# AwsCommunity::Account::AlternateContact
+
+An alternate contact attached to an Amazon Web Services account.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "Type" : "AwsCommunity::Account::AlternateContact",
+    "Properties" : {
+        "<a href="#accountid" title="AccountId">AccountId</a>" : <i>String</i>,
+        "<a href="#alternatecontacttype" title="AlternateContactType">AlternateContactType</a>" : <i>String</i>,
+        "<a href="#emailaddress" title="EmailAddress">EmailAddress</a>" : <i>String</i>,
+        "<a href="#name" title="Name">Name</a>" : <i>String</i>,
+        "<a href="#phonenumber" title="PhoneNumber">PhoneNumber</a>" : <i>String</i>,
+        "<a href="#title" title="Title">Title</a>" : <i>String</i>
+    }
+}
+</pre>
+
+### YAML
+
+<pre>
+Type: AwsCommunity::Account::AlternateContact
+Properties:
+    <a href="#accountid" title="AccountId">AccountId</a>: <i>String</i>
+    <a href="#alternatecontacttype" title="AlternateContactType">AlternateContactType</a>: <i>String</i>
+    <a href="#emailaddress" title="EmailAddress">EmailAddress</a>: <i>String</i>
+    <a href="#name" title="Name">Name</a>: <i>String</i>
+    <a href="#phonenumber" title="PhoneNumber">PhoneNumber</a>: <i>String</i>
+    <a href="#title" title="Title">Title</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### AccountId
+
+The account ID of the AWS account that you want to add an alternate contact to. If you do not specify this parameter, it defaults to the current AWS account.
+
+_Required_: Yes
+
+_Type_: String
+
+_Pattern_: <code>^\d{12}$</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### AlternateContactType
+
+The type of alternate contact you want to create.
+
+_Required_: Yes
+
+_Type_: String
+
+_Allowed Values_: <code>BILLING</code> | <code>OPERATIONS</code> | <code>SECURITY</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### EmailAddress
+
+The email address for the alternate contact.
+
+_Required_: Yes
+
+_Type_: String
+
+_Pattern_: <code>^[\s]*[\w+=.#!&-]+@[\w.-]+\.[\w]+[\s]*$</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Name
+
+The name for the alternate contact.
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum Length_: <code>1</code>
+
+_Maximum Length_: <code>64</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### PhoneNumber
+
+The phone number for the alternate contact.
+
+_Required_: Yes
+
+_Type_: String
+
+_Pattern_: <code>^[\s0-9()+-]{1,25}$</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Title
+
+The title for the alternate contact.
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum Length_: <code>1</code>
+
+_Maximum Length_: <code>50</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/resources/Account_AlternateContact/inputs/inputs_1_create.json
+++ b/resources/Account_AlternateContact/inputs/inputs_1_create.json
@@ -1,0 +1,8 @@
+{
+    "AccountId": "{{AccountAlternateContactCurrentAccountId}}",
+    "AlternateContactType": "OPERATIONS",
+    "EmailAddress": "operations+112233445566@example.com",
+    "Name": "Operations Distribution List",
+    "PhoneNumber": "+1 206-555-1233",
+    "Title": "Ops"
+}

--- a/resources/Account_AlternateContact/inputs/inputs_1_invalid.json
+++ b/resources/Account_AlternateContact/inputs/inputs_1_invalid.json
@@ -1,0 +1,8 @@
+{
+    "AccountId": "{{AccountAlternateContactCurrentAccountId}}",
+    "AlternateContactType": "OPERATIONS",
+    "EmailAddress": "NO-EMAIL",
+    "Name": "Operations Distribution List",
+    "PhoneNumber": "+1 206-555-1233",
+    "Title": "Ops"
+}

--- a/resources/Account_AlternateContact/inputs/inputs_1_update.json
+++ b/resources/Account_AlternateContact/inputs/inputs_1_update.json
@@ -1,0 +1,8 @@
+{
+    "AccountId": "{{AccountAlternateContactCurrentAccountId}}",
+    "AlternateContactType": "OPERATIONS",
+    "EmailAddress": "operations+new@example.com",
+    "Name": "Operations Distribution List (new)",
+    "PhoneNumber": "+1 206-555-0000",
+    "Title": "New Ops"
+}

--- a/resources/Account_AlternateContact/requirements.txt
+++ b/resources/Account_AlternateContact/requirements.txt
@@ -1,0 +1,1 @@
+cloudformation-cli-python-lib>=2.1.9

--- a/resources/Account_AlternateContact/resource-role.yaml
+++ b/resources/Account_AlternateContact/resource-role.yaml
@@ -1,0 +1,40 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  This CloudFormation template creates a role assumed by CloudFormation
+  during CRUDL operations to mutate resources on behalf of the customer.
+
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      MaxSessionDuration: 8400
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: resources.cloudformation.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AwsCommunity-Account-AlternateContact/*
+      Path: "/"
+      Policies:
+        - PolicyName: ResourceTypePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                - "account:DeleteAlternateContact"
+                - "account:GetAlternateContact"
+                - "account:PutAlternateContact"
+                Resource: "*"
+Outputs:
+  ExecutionRoleArn:
+    Value:
+      Fn::GetAtt: ExecutionRole.Arn

--- a/resources/Account_AlternateContact/src/awscommunity_account_alternatecontact/actions.py
+++ b/resources/Account_AlternateContact/src/awscommunity_account_alternatecontact/actions.py
@@ -1,0 +1,139 @@
+"""Actions executed by the resource."""
+from typing import Mapping
+
+from cloudformation_cli_python_lib import SessionProxy
+from cloudformation_cli_python_lib.exceptions import (
+    AlreadyExists,
+    InvalidRequest,
+    AccessDenied,
+    Throttling,
+    ServiceInternalError,
+    NotFound,
+)
+
+from .constants import TYPE_NAME
+from .models import ResourceModel
+
+
+def create(session: SessionProxy, model: ResourceModel, current_account_id: str):
+    """Create a resource based on the model"""
+    if _exists(session, model, current_account_id):
+        raise AlreadyExists(TYPE_NAME, get_identifier(model))
+    _put(session, model, current_account_id)
+
+
+def update(session: SessionProxy, model: ResourceModel, current_account_id: str) -> None:
+    """Update a resource based on the model"""
+    if not _exists(session, model, current_account_id):
+        raise NotFound(TYPE_NAME, get_identifier(model))
+    _put(session, model, current_account_id)
+
+
+def delete(session: SessionProxy, model: ResourceModel, current_account_id: str) -> None:
+    """Delete a resource based on the model."""
+    # We don't need to check if it exists, the API returns an error if it doesn't
+    _delete(session, model, current_account_id)
+
+
+def read(session: SessionProxy, model: ResourceModel, current_account_id: str) -> ResourceModel:
+    """Read the resource, using the identifier in the model."""
+    # We don't need to check if it exists, the API returns an error if it doesn't
+    return _get(session, model, current_account_id)
+
+
+def get_identifier(model: ResourceModel) -> str:
+    """Return the identifier as a string (it's a combined identifier)."""
+    return f"{model.AccountId}/{model.AlternateContactType}"
+
+
+def _exists(session: SessionProxy, model: ResourceModel, current_account_id: str) -> bool:
+    """Check if the given resource exists."""
+    try:
+        _get(session, model, current_account_id)
+        return True
+    except NotFound:
+        return False
+
+
+def _put(session: SessionProxy, model: ResourceModel, current_account_id: str) -> None:
+    """Create or update the resource."""
+    account = session.client("account")
+    try:
+        account.put_alternate_contact(
+            AlternateContactType=model.AlternateContactType,
+            EmailAddress=model.EmailAddress,
+            Name=model.Name,
+            PhoneNumber=model.PhoneNumber,
+            Title=model.Title,
+            **_api_kwargs(current_account_id, model),
+        )
+    except account.exceptions.ValidationException as e:
+        raise InvalidRequest(e) from e
+    except account.exceptions.AccessDeniedException as e:
+        raise AccessDenied(e) from e
+    except account.exceptions.TooManyRequestsException as e:
+        raise Throttling(e) from e
+    except account.exceptions.InternalServerException as e:
+        raise ServiceInternalError(e) from e
+
+
+def _delete(session: SessionProxy, model: ResourceModel, current_account_id: str) -> None:
+    """Remove the resource."""
+    account = session.client("account")
+    try:
+        account.delete_alternate_contact(
+            AlternateContactType=model.AlternateContactType,
+            **_api_kwargs(current_account_id, model),
+        )
+    except account.exceptions.ResourceNotFoundException as e:
+        raise NotFound(TYPE_NAME, get_identifier(model)) from e
+    except account.exceptions.ValidationException as e:
+        raise InvalidRequest(e) from e
+    except account.exceptions.AccessDeniedException as e:
+        raise AccessDenied(e) from e
+    except account.exceptions.TooManyRequestsException as e:
+        raise Throttling(e) from e
+    except account.exceptions.InternalServerException as e:
+        raise ServiceInternalError(e) from e
+
+
+def _get(session: SessionProxy, model: ResourceModel, current_account_id: str) -> ResourceModel:
+    """Get the current configuration"""
+    account = session.client("account")
+    try:
+        info = account.get_alternate_contact(
+            AlternateContactType=model.AlternateContactType,
+            **_api_kwargs(current_account_id, model),
+        )["AlternateContact"]
+        return ResourceModel(
+            AccountId=model.AccountId,  # not returned in response
+            AlternateContactType=info["AlternateContactType"],
+            EmailAddress=info["EmailAddress"],
+            Name=info["Name"],
+            PhoneNumber=info["PhoneNumber"],
+            Title=info["Title"],
+        )
+    except account.exceptions.ResourceNotFoundException as e:
+        raise NotFound(TYPE_NAME, get_identifier(model)) from e
+    except account.exceptions.ValidationException as e:
+        raise InvalidRequest(e) from e
+    except account.exceptions.AccessDeniedException as e:
+        raise AccessDenied(e) from e
+    except account.exceptions.TooManyRequestsException as e:
+        raise Throttling(e) from e
+    except account.exceptions.InternalServerException as e:
+        raise ServiceInternalError(e) from e
+
+
+def _api_kwargs(account_id: str, model: ResourceModel) -> Mapping:
+    """
+    Return arguments for account api that are dependend on the targeted account.
+
+    This is needed, because the Account API will throw access denied if you specify
+    the accountId when you're not the management account (even if the account id
+    is your own account).
+    """
+    if account_id == model.AccountId:
+        return {}
+
+    return {"AccountId": model.AccountId}

--- a/resources/Account_AlternateContact/src/awscommunity_account_alternatecontact/constants.py
+++ b/resources/Account_AlternateContact/src/awscommunity_account_alternatecontact/constants.py
@@ -1,0 +1,2 @@
+"""Constants for the resource."""
+TYPE_NAME = "AwsCommunity::Account::AlternateContact"

--- a/resources/Account_AlternateContact/src/awscommunity_account_alternatecontact/handlers.py
+++ b/resources/Account_AlternateContact/src/awscommunity_account_alternatecontact/handlers.py
@@ -1,0 +1,108 @@
+"""Main entrypoints."""
+import logging
+from typing import Any, MutableMapping, Optional
+from cloudformation_cli_python_lib import (
+    Action,
+    OperationStatus,
+    ProgressEvent,
+    Resource,
+    SessionProxy,
+)
+from cloudformation_cli_python_lib.exceptions import InternalFailure, InvalidRequest
+
+from .actions import create, update, delete, get_identifier, read
+from .constants import TYPE_NAME
+from .models import ResourceHandlerRequest, ResourceModel
+
+# Use this logger to forward log messages to CloudWatch Logs.
+LOG = logging.getLogger(__name__)
+
+resource = Resource(TYPE_NAME, ResourceModel)
+test_entrypoint = resource.test_entrypoint
+
+
+@resource.handler(Action.CREATE)
+def create_handler(
+    session: Optional[SessionProxy],
+    request: ResourceHandlerRequest,
+    callback_context: MutableMapping[str, Any],  # pylint:disable=unused-argument
+) -> ProgressEvent:
+    """Create handler."""
+    if not isinstance(session, SessionProxy):
+        raise InternalFailure("Session is not a SessionProxy")
+
+    model = request.desiredResourceState
+    create(
+        session, model, request.awsAccountId
+    )  # api is different depending on the current aws account
+    return ProgressEvent(
+        status=OperationStatus.SUCCESS,
+        resourceModel=model,
+    )
+
+
+@resource.handler(Action.UPDATE)
+def update_handler(
+    session: Optional[SessionProxy],
+    request: ResourceHandlerRequest,
+    callback_context: MutableMapping[str, Any],  # pylint:disable=unused-argument
+) -> ProgressEvent:
+    """Update handler."""
+    if not isinstance(session, SessionProxy):
+        raise InternalFailure("Session is not a SessionProxy")
+
+    if get_identifier(request.previousResourceState) != get_identifier(
+        request.desiredResourceState
+    ):
+        raise InvalidRequest("Identifier changed between previous and desired state")
+
+    # We can overwrite everything that is not the identifier, so we don't have
+    # to look at the previous state
+    model = request.desiredResourceState
+    update(
+        session, model, request.awsAccountId
+    )  # api is different depending on the current aws account
+    return ProgressEvent(
+        status=OperationStatus.SUCCESS,
+        resourceModel=model,
+    )
+
+
+@resource.handler(Action.DELETE)
+def delete_handler(
+    session: Optional[SessionProxy],
+    request: ResourceHandlerRequest,
+    callback_context: MutableMapping[str, Any],  # pylint:disable=unused-argument
+) -> ProgressEvent:
+    """Delete handler."""
+    if not isinstance(session, SessionProxy):
+        raise InternalFailure("Session is not a SessionProxy")
+
+    model = request.desiredResourceState
+    delete(
+        session, model, request.awsAccountId
+    )  # api is different depending on the current aws account
+    return ProgressEvent(
+        status=OperationStatus.SUCCESS,
+        resourceModel=None,
+    )
+
+
+@resource.handler(Action.READ)
+def read_handler(
+    session: Optional[SessionProxy],
+    request: ResourceHandlerRequest,
+    callback_context: MutableMapping[str, Any],  # pylint:disable=unused-argument
+) -> ProgressEvent:
+    """Read handler."""
+    if not isinstance(session, SessionProxy):
+        raise InternalFailure("Session is not a SessionProxy")
+
+    model = request.desiredResourceState
+    model = read(
+        session, model, request.awsAccountId
+    )  # api is different depending on the current aws account
+    return ProgressEvent(
+        status=OperationStatus.SUCCESS,
+        resourceModel=model,
+    )

--- a/resources/Account_AlternateContact/src/awscommunity_account_alternatecontact/models.py
+++ b/resources/Account_AlternateContact/src/awscommunity_account_alternatecontact/models.py
@@ -1,0 +1,87 @@
+# DO NOT modify this file by hand, changes will be overwritten
+from dataclasses import dataclass
+
+from cloudformation_cli_python_lib.interface import (
+    BaseModel,
+    BaseResourceHandlerRequest,
+)
+from cloudformation_cli_python_lib.recast import recast_object
+from cloudformation_cli_python_lib.utils import deserialize_list
+
+import sys
+from inspect import getmembers, isclass
+from typing import (
+    AbstractSet,
+    Any,
+    Generic,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+)
+
+T = TypeVar("T")
+
+
+def set_or_none(value: Optional[Sequence[T]]) -> Optional[AbstractSet[T]]:
+    if value:
+        return set(value)
+    return None
+
+
+@dataclass
+class ResourceHandlerRequest(BaseResourceHandlerRequest):
+    # pylint: disable=invalid-name
+    desiredResourceState: Optional["ResourceModel"]
+    previousResourceState: Optional["ResourceModel"]
+    typeConfiguration: Optional["TypeConfigurationModel"]
+
+
+@dataclass
+class ResourceModel(BaseModel):
+    AccountId: Optional[str]
+    AlternateContactType: Optional[str]
+    EmailAddress: Optional[str]
+    Name: Optional[str]
+    PhoneNumber: Optional[str]
+    Title: Optional[str]
+
+    @classmethod
+    def _deserialize(
+        cls: Type["_ResourceModel"],
+        json_data: Optional[Mapping[str, Any]],
+    ) -> Optional["_ResourceModel"]:
+        if not json_data:
+            return None
+        dataclasses = {n: o for n, o in getmembers(sys.modules[__name__]) if isclass(o)}
+        recast_object(cls, json_data, dataclasses)
+        return cls(
+            AccountId=json_data.get("AccountId"),
+            AlternateContactType=json_data.get("AlternateContactType"),
+            EmailAddress=json_data.get("EmailAddress"),
+            Name=json_data.get("Name"),
+            PhoneNumber=json_data.get("PhoneNumber"),
+            Title=json_data.get("Title"),
+        )
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_ResourceModel = ResourceModel
+
+
+@dataclass
+class TypeConfigurationModel(BaseModel):
+    @classmethod
+    def _deserialize(
+        cls: Type["_TypeConfigurationModel"],
+        json_data: Optional[Mapping[str, Any]],
+    ) -> Optional["_TypeConfigurationModel"]:
+        if not json_data:
+            return None
+        return cls()
+
+
+# work around possible type aliasing issues when variable has same name as a model
+_TypeConfigurationModel = TypeConfigurationModel

--- a/resources/Account_AlternateContact/template.yml
+++ b/resources/Account_AlternateContact/template.yml
@@ -1,0 +1,23 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: AWS SAM template for the AwsCommunity::Account::AlternateContact resource type
+
+Globals:
+  Function:
+    Timeout: 180  # docker start-up times can be long for SAM CLI
+    MemorySize: 256
+
+Resources:
+  TypeFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: awscommunity_account_alternatecontact.handlers.resource
+      Runtime: python3.7
+      CodeUri: build/
+
+  TestEntrypoint:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: awscommunity_account_alternatecontact.handlers.test_entrypoint
+      Runtime: python3.7
+      CodeUri: build/

--- a/resources/Account_AlternateContact/test/integ.yml
+++ b/resources/Account_AlternateContact/test/integ.yml
@@ -1,0 +1,11 @@
+Resources:
+  OperationsContact:
+    Type: AwsCommunity::Account::AlternateContact
+    Properties:
+      AccountId: !Ref "AWS::AccountId"
+      # we only test OPERATIONS as we don't want to change security or billing
+      AlternateContactType: OPERATIONS
+      EmailAddress: operations@example.com
+      Name: Operations Distribution List
+      PhoneNumber: +12065550000
+      Title: Ops

--- a/resources/Account_AlternateContact/test/setup.yml
+++ b/resources/Account_AlternateContact/test/setup.yml
@@ -1,0 +1,13 @@
+  # We do not need any resources, but we need to know the account id.
+  # When testing in a management account, we might want to add accounts to test
+  # with here
+Resources:
+  # Any resource would be fine, these are easy and don't require permissions
+  Dummy:
+    Type: AWS::CloudFormation::WaitConditionHandle
+Outputs:
+  CurrentAccountId:
+    Description: The account id of the current account
+    Value: !Ref "AWS::AccountId"
+    Export:
+      Name: AccountAlternateContactCurrentAccountId


### PR DESCRIPTION
*Description of changes:*
This adds the code for an AwsCommunity::Account::AlternateContact resource.

Note that for testing, the Operations contact can't be set in the account.

I did not test this (yet?) with an Organizations account, but I believe the code should work for that case too

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
