### PR TITLE
Remove line about leaving out the AccountId

### DIFF
--- a/resources/Account_AlternateContact/awscommunity-account-alternatecontact.json
+++ b/resources/Account_AlternateContact/awscommunity-account-alternatecontact.json
@@ -6,7 +6,7 @@
     },
     "properties": {
         "AccountId": {
-            "description": "The account ID of the AWS account that you want to add an alternate contact to. If you do not specify this parameter, it defaults to the current AWS account.",
+            "description": "The account ID of the AWS account that you want to add an alternate contact to.",
             "type": "string",
             "pattern": "^\\d{12}$"
         },

--- a/resources/Account_AlternateContact/docs/README.md
+++ b/resources/Account_AlternateContact/docs/README.md
@@ -39,7 +39,7 @@ Properties:
 
 #### AccountId
 
-The account ID of the AWS account that you want to add an alternate contact to. If you do not specify this parameter, it defaults to the current AWS account.
+The account ID of the AWS account that you want to add an alternate contact to.
 
 _Required_: Yes
 

--- a/resources/Account_AlternateContact/src/awscommunity_account_alternatecontact/models.py
+++ b/resources/Account_AlternateContact/src/awscommunity_account_alternatecontact/models.py
@@ -73,6 +73,7 @@ _ResourceModel = ResourceModel
 
 @dataclass
 class TypeConfigurationModel(BaseModel):
+
     @classmethod
     def _deserialize(
         cls: Type["_TypeConfigurationModel"],
@@ -80,8 +81,11 @@ class TypeConfigurationModel(BaseModel):
     ) -> Optional["_TypeConfigurationModel"]:
         if not json_data:
             return None
-        return cls()
+        return cls(
+        )
 
 
 # work around possible type aliasing issues when variable has same name as a model
 _TypeConfigurationModel = TypeConfigurationModel
+
+


### PR DESCRIPTION
AccountId is required for the resource

This is doc/schema only (and cfn generated files, you'll see changes because the previous version was auto-formatted)

I don't think this warrants its own release, but it can be include whenever another release happens



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
