### PR TITLE
Update github action pip-audit to 1.0.6

### DIFF
--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -33,12 +33,15 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install pip-audit on non-Windows
         run: |
+          python -m venv env/
+          source env/bin/activate
           pip install pip-audit
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3
       - name: 'Pip Audit'
         uses: pypa/gh-action-pip-audit@v1.0.6
         with:
+          virtual-environment: env/
           inputs: ${{ matrix.files }}
 
   rust-files:

--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -31,6 +31,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+      - name: Install pip-audit on non-Windows
+        run: |
+          pip install pip-audit==2.5.0
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3
       - name: 'Pip Audit'

--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install pip-audit on non-Windows
         run: |
-          pip install pip-audit==2.5.0
+          pip install pip-audit==2.4.13
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3
       - name: 'Pip Audit'

--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -31,17 +31,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - name: Install pip-audit on non-Windows
-        run: |
-          python -m venv env/
-          source env/bin/activate
-          pip install pip-audit
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3
       - name: 'Pip Audit'
         uses: pypa/gh-action-pip-audit@v1.0.6
         with:
-          virtual-environment: env/
           inputs: ${{ matrix.files }}
 
   rust-files:

--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3
       - name: 'Pip Audit'
-        uses: pypa/gh-action-pip-audit@v1.0.5
+        uses: pypa/gh-action-pip-audit@v1.0.6
         with:
           inputs: ${{ matrix.files }}
 

--- a/packages/cfn_guard_rs_hook/example/requirements.txt
+++ b/packages/cfn_guard_rs_hook/example/requirements.txt
@@ -1,4 +1,4 @@
 cloudformation-cli-python-lib>=2.1.9
 Jinja2==3.1.2
 cfn_guard_rs>=0.1.0
-/project/cfn_guard_rs_hook-0.1.0-py3-none-any.whl
+cfn_guard_rs_hook>=0.1.0

--- a/release/requirements.txt
+++ b/release/requirements.txt
@@ -2,7 +2,7 @@ importlib_metadata==4.7.1
 cfn-lint==0.64.1
 cloudformation-cli==0.2.28
 cloudformation-cli-python-lib==2.1.15
-cloudformation-cli-python-plugin.git==2.1.7
+cloudformation-cli-python-plugin==2.1.7
 cloudformation-cli-java-plugin==2.0.12
 cloudformation-cli-typescript-plugin==1.0.1
 cloudformation-cli-go-plugin==2.0.4


### PR DESCRIPTION
Issue #171 

Update to github action for pip-audit to 1.0.6.  This checks for pip-audit-output file existence before accessing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
