### PR TITLE
Adding Fastly TLS Resources to CICD

### DIFF
--- a/release/fastly/cicd.yml
+++ b/release/fastly/cicd.yml
@@ -221,7 +221,7 @@ Resources:
       ServiceRole: !GetAtt FastlyServicesDomainBuildProjectRole.Arn
       Source:
         Type: CODEPIPELINE
-        BuildSpec: !Sub "${Env}-buildspec-typescript.yml"
+        BuildSpec: !Sub "${Env}-buildspec.yml"
 
   FastlyServicesBackendBuildProject:
     Type: AWS::CodeBuild::Project
@@ -248,7 +248,7 @@ Resources:
       ServiceRole: !GetAtt FastlyServicesBackendBuildProjectRole.Arn
       Source:
         Type: CODEPIPELINE
-        BuildSpec: !Sub "${Env}-buildspec-typescript.yml"
+        BuildSpec: !Sub "${Env}-buildspec.yml"
 
   FastlyServicesHealthcheckBuildProject:
     Type: AWS::CodeBuild::Project
@@ -275,7 +275,7 @@ Resources:
       ServiceRole: !GetAtt FastlyServicesHealthcheckBuildProjectRole.Arn
       Source:
         Type: CODEPIPELINE
-        BuildSpec: !Sub "${Env}-buildspec-typescript.yml"
+        BuildSpec: !Sub "${Env}-buildspec.yml"
 
   FastlyServicesServiceBuildProject:
     Type: AWS::CodeBuild::Project
@@ -296,7 +296,7 @@ Resources:
       ServiceRole: !GetAtt FastlyServicesServiceBuildProjectRole.Arn
       Source:
         Type: CODEPIPELINE
-        BuildSpec: !Sub "${Env}-buildspec-typescript.yml"
+        BuildSpec: !Sub "${Env}-buildspec.yml"
 
   FastlyDictionaryDictionaryBuildProject:
     Type: AWS::CodeBuild::Project
@@ -323,7 +323,7 @@ Resources:
       ServiceRole: !GetAtt FastlyDictionaryDictionaryBuildProjectRole.Arn
       Source:
         Type: CODEPIPELINE
-        BuildSpec: !Sub "${Env}-buildspec-typescript.yml"
+        BuildSpec: !Sub "${Env}-buildspec.yml"
 
   FastlyDictionaryDictionaryItemBuildProject:
     Type: AWS::CodeBuild::Project
@@ -347,10 +347,13 @@ Resources:
         - Name: FASTLY_VERSION_ID
           Type: PARAMETER_STORE
           Value: "cep-fastly-version-id"
+        - Name: FASTLY_DICTIONARY_ID
+          Type: PARAMETER_STORE
+          Value: "cep-fastly-dictionary-id"
       ServiceRole: !GetAtt FastlyDictionaryDictionaryItemBuildProjectRole.Arn
       Source:
         Type: CODEPIPELINE
-        BuildSpec: !Sub "${Env}-buildspec-typescript.yml"
+        BuildSpec: !Sub "${Env}-buildspec.yml"
 
   FastlyLoggingS3BuildProject:
     Type: AWS::CodeBuild::Project
@@ -377,7 +380,7 @@ Resources:
       ServiceRole: !GetAtt FastlyLoggingS3BuildProjectRole.Arn
       Source:
         Type: CODEPIPELINE
-        BuildSpec: !Sub "${Env}-buildspec-typescript.yml"
+        BuildSpec: !Sub "${Env}-buildspec.yml"
 
   FastlyLoggingSplunkBuildProject:
     Type: AWS::CodeBuild::Project
@@ -404,7 +407,128 @@ Resources:
       ServiceRole: !GetAtt FastlyLoggingSplunkBuildProjectRole.Arn
       Source:
         Type: CODEPIPELINE
-        BuildSpec: !Sub "${Env}-buildspec-typescript.yml"
+        BuildSpec: !Sub "${Env}-buildspec.yml"
+
+
+  FastlyTlsCertificateBuildProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - Fn::ImportValue: !Sub "cep-${Env}-common-build-project-policy"
+        - !Ref FastlyParameterPolicy
+
+  FastlyTlsCertificateBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub "${PrefixLower}-${Env}-${PrefixLower}-tls-certificate"
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_LARGE
+        Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/cep-cicd:latest"
+        ImagePullCredentialsType: SERVICE_ROLE
+        PrivilegedMode: true
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: RESOURCE_PATH
+            Type: PLAINTEXT
+            Value: "Fastly-Tls-Certificate"
+          - Name: FASTLY_TLS_CERTIFICATE
+            Type: PARAMETER_STORE
+            Value: "cep-fastly-tls-certificate"
+      ServiceRole: !GetAtt FastlyTlsCertificateBuildProjectRole.Arn
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: !Sub "${Env}-buildspec.yml"
+
+  FastlyTlsDomainBuildProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - Fn::ImportValue: !Sub "cep-${Env}-common-build-project-policy"
+        - !Ref FastlyParameterPolicy
+
+  FastlyTlsDomainBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub "${PrefixLower}-${Env}-${PrefixLower}-tls-domain"
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_LARGE
+        Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/cep-cicd:latest"
+        ImagePullCredentialsType: SERVICE_ROLE
+        PrivilegedMode: true
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: RESOURCE_PATH
+            Type: PLAINTEXT
+            Value: "Fastly-Tls-Domain"
+          - Name: FASTLY_TLS_CERT_ID
+            Type: PARAMETER_STORE
+            Value: "cep-fastly-tls-cert-id"
+          - Name: FASTLY_TLS_DOMAIN_ID
+            Type: PARAMETER_STORE
+            Value: "cep-fastly-tls-domain-id"
+          - Name: FASTLY_TLS_CONFIG_ID
+            Type: PARAMETER_STORE
+            Value: "cep-fastly-tls-config-id"
+      ServiceRole: !GetAtt FastlyTlsDomainBuildProjectRole.Arn
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: !Sub "${Env}-buildspec.yml"
+
+  FastlyTlsPrivateKeysBuildProjectRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: '2012-10-17'
+      ManagedPolicyArns:
+        - Fn::ImportValue: !Sub "cep-${Env}-common-build-project-policy"
+        - !Ref FastlyParameterPolicy
+
+  FastlyTlsPrivateKeysBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub "${PrefixLower}-${Env}-${PrefixLower}-tls-privatekeys"
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_LARGE
+        Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/cep-cicd:latest"
+        ImagePullCredentialsType: SERVICE_ROLE
+        PrivilegedMode: true
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - Name: RESOURCE_PATH
+            Type: PLAINTEXT
+            Value: "Fastly-Tls-PrivateKeys"
+          - Name: FASTLY_PRIVATE_KEY
+            Type: PARAMETER_STORE
+            Value: "cep-fastly-tls-privatekey"
+      ServiceRole: !GetAtt FastlyTlsPrivateKeysBuildProjectRole.Arn
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: !Sub "${Env}-buildspec.yml"
 
   SourceBucket:
     Type: AWS::S3::Bucket
@@ -466,6 +590,9 @@ Resources:
                   - !GetAtt FastlyDictionaryDictionaryItemBuildProject.Arn
                   - !GetAtt FastlyLoggingS3BuildProject.Arn
                   - !GetAtt FastlyLoggingSplunkBuildProject.Arn
+                  - !GetAtt FastlyTlsCertificateBuildProject.Arn
+                  - !GetAtt FastlyTlsDomainBuildProject.Arn
+                  - !GetAtt FastlyTlsPrivateKeysBuildProject.Arn
               - Action:
                   - kms:*
                 Effect: Allow
@@ -527,6 +654,9 @@ Resources:
                 - !GetAtt FastlyDictionaryDictionaryItemBuildProjectRole.Arn
                 - !GetAtt FastlyLoggingS3BuildProjectRole.Arn
                 - !GetAtt FastlyLoggingSplunkBuildProjectRole.Arn
+                - !GetAtt FastlyTlsCertificateBuildProjectRole.Arn
+                - !GetAtt FastlyTlsPrivateKeysBuildProjectRole.Arn
+                - !GetAtt FastlyTlsDomainBuildProjectRole.Arn
             Resource: "*"
       MultiRegion: true
 
@@ -728,6 +858,63 @@ Resources:
                       "name": "RESOURCE_PATH",
                       "type": "PLAINTEXT",
                       "value": "Fastly-Logging-Splunk"
+                    }
+                  ]
+              RunOrder: 1
+            - Name: FastlyTlsCertificate
+              InputArtifacts:
+                - Name: extensions-source
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: 1
+              Configuration:
+                ProjectName: !Ref FastlyTlsCertificateBuildProject
+                EnvironmentVariables: |-
+                  [
+                    {
+                      "name": "RESOURCE_PATH",
+                      "type": "PLAINTEXT",
+                      "value": "Fastly-Tls-Certificate"
+                    }
+                  ]
+              RunOrder: 1
+            - Name: FastlyTlsDomain
+              InputArtifacts:
+                - Name: extensions-source
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: 1
+              Configuration:
+                ProjectName: !Ref FastlyTlsDomainBuildProject
+                EnvironmentVariables: |-
+                  [
+                    {
+                      "name": "RESOURCE_PATH",
+                      "type": "PLAINTEXT",
+                      "value": "Fastly-Tls-Domain"
+                    }
+                  ]
+              RunOrder: 1
+            - Name: FastlyTlsPrivateKeys
+              InputArtifacts:
+                - Name: extensions-source
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Provider: CodeBuild
+                Version: 1
+              Configuration:
+                ProjectName: !Ref FastlyTlsPrivateKeysBuildProject
+                EnvironmentVariables: |-
+                  [
+                    {
+                      "name": "RESOURCE_PATH",
+                      "type": "PLAINTEXT",
+                      "value": "Fastly-Tls-PrivateKeys"
                     }
                   ]
               RunOrder: 1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1.Adding below Resources to CICD :
Fastly-Tls-Certificate
Fastly-Tls-Domain
Fastly-Tls-PrivateKeys
2.Fixing Prod pipeline issue for existing resources 

Testing: 
Local Alpha, Beta and Prod are successful 

<img width="1031" alt="image" src="https://user-images.githubusercontent.com/118321621/226985611-c2862fd2-6119-42c7-860f-0bb082ffc425.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
