### PR TITLE
update pip-audit to newest working version

### DIFF
--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install pip-audit on non-Windows
         run: |
-          pip install pip-audit==2.4.13
+          pip install "pip-audit>=2.5.3"
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3
       - name: 'Pip Audit'


### PR DESCRIPTION
Closes #171 

Pip-audit 2.5.0, 2.5.1, 2.5.2 had regression in log error handling.  This was fixed in 2.5.3.  Put in explicit update for pip-audit to at least v2.5.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
