### PR TITLE
Cryptography fix

### DIFF
--- a/hooks/CloudFront_LoggingEnabled/requirements-dev.txt
+++ b/hooks/CloudFront_LoggingEnabled/requirements-dev.txt
@@ -1,6 +1,6 @@
 cfn-lint==0.64.1
 cloudformation-cli==0.2.28
-cloudformation-cli-python-lib==2.1.15
-cloudformation-cli-python-plugin==2.1.7
+cloudformation-cli-python-lib>2.1.15
+cloudformation-cli-python-plugin>2.1.7
 pylint==2.15.2
 pytest==7.2.0

--- a/hooks/EC2_SecurityGroupRestrictedSSH/requirements-dev.txt
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/requirements-dev.txt
@@ -1,7 +1,6 @@
 cfn-lint==0.64.1
 cloudformation-cli==0.2.28
-cloudformation-cli-python-lib==2.1.15
-cloudformation-cli-python-plugin==2.1.7
-git+https://github.com/aws-cloudformation/cloudformation-cli-python-plugin.git@master
+cloudformation-cli-python-lib>2.1.15
+cloudformation-cli-python-plugin>2.1.7
 pylint==2.15.2
 pytest==7.2.0

--- a/hooks/EC2_SecurityGroupRestrictedSSH/requirements.txt
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/requirements.txt
@@ -1,3 +1,2 @@
-cloudformation-cli-python-lib>=2.1.15
+cloudformation-cli-python-lib>2.1.15
 cfn-guard-rs-hook>=0.2.2
-cryptography<40.0.0

--- a/hooks/KMS_EncryptionSettings/requirements-dev.txt
+++ b/hooks/KMS_EncryptionSettings/requirements-dev.txt
@@ -2,5 +2,5 @@
 #   python3 -m pip install -r requirements-dev.txt
 cloudformation-cli>=0.2.28
 cloudformation-cli-java-plugin>=2.0.14
-cloudformation-cli-python-lib>=2.1.15
+cloudformation-cli-python-lib>2.1.15
 pytest>=7.2.0

--- a/hooks/KMS_EncryptionSettings/requirements.txt
+++ b/hooks/KMS_EncryptionSettings/requirements.txt
@@ -1,4 +1,4 @@
 # To install the following requirements, run:
 #   python3 -m pip install -r requirements.txt
-cloudformation-cli-python-lib>=2.1.15
+cloudformation-cli-python-lib>2.1.15
 pytest>=7.2.0

--- a/hooks/S3_BucketVersioningEnabled/requirements-dev.txt
+++ b/hooks/S3_BucketVersioningEnabled/requirements-dev.txt
@@ -1,7 +1,6 @@
 cfn-lint==0.64.1
 cloudformation-cli==0.2.28
-cloudformation-cli-python-lib==2.1.15
-cloudformation-cli-python-plugin==2.1.7
-git+https://github.com/aws-cloudformation/cloudformation-cli-python-plugin.git@master
+cloudformation-cli-python-lib>2.1.15
+cloudformation-cli-python-plugin>2.1.7
 pylint==2.15.2
 pytest==7.2.0

--- a/hooks/S3_BucketVersioningEnabled/requirements.txt
+++ b/hooks/S3_BucketVersioningEnabled/requirements.txt
@@ -1,2 +1,2 @@
-cloudformation-cli-python-lib>=2.1.15
+cloudformation-cli-python-lib>2.1.15
 cfn-guard-rs-hook>=0.1.1

--- a/hooks/S3_BucketVersioningEnabled/requirements.txt
+++ b/hooks/S3_BucketVersioningEnabled/requirements.txt
@@ -1,3 +1,2 @@
-cloudformation-cli-python-lib>=2.1.9
+cloudformation-cli-python-lib>=2.1.15
 cfn-guard-rs-hook>=0.1.1
-cryptography<40.0.0

--- a/hooks/S3_PublicAccessControlsRestricted/requirements-dev.txt
+++ b/hooks/S3_PublicAccessControlsRestricted/requirements-dev.txt
@@ -1,6 +1,6 @@
 cfn-lint==0.73.1
 git+https://github.com/aws-cloudformation/cloudformation-cli.git@master
-cloudformation-cli-python-lib==2.1.15
-cloudformation-cli-python-plugin==2.1.7
+cloudformation-cli-python-lib>2.1.15
+cloudformation-cli-python-plugin>2.1.7
 pylint==2.15.2
 pytest==7.2.0

--- a/hooks/S3_PublicAccessControlsRestricted/requirements.txt
+++ b/hooks/S3_PublicAccessControlsRestricted/requirements.txt
@@ -1,3 +1,3 @@
-cloudformation-cli-python-lib>=2.1.15
+cloudformation-cli-python-lib>2.1.15
 cfn-guard-rs-hook>=0.2.2
-cryptography<40.0.0
+

--- a/modules/alpha-buildspec.yml
+++ b/modules/alpha-buildspec.yml
@@ -8,7 +8,6 @@ phases:
       - echo Entered the install phase...
       - echo About to build $MODULE_PATH
       - export PATH="/usr/local/bin:$PATH"
-      - pip install "cryptography<40.0.0"
       - pip install git+https://github.com/aws-cloudformation/cloudformation-cli.git@master
       - pip install git+https://github.com/aws-cloudformation/cloudformation-cli-python-plugin.git@master
       - cd $MODULE_PATH

--- a/release/requirements.txt
+++ b/release/requirements.txt
@@ -1,9 +1,8 @@
 importlib_metadata==4.7.1
 cfn-lint==0.64.1
-cryptography<40.0.0
 cloudformation-cli==0.2.28
-cloudformation-cli-python-lib==2.1.15
-cloudformation-cli-python-plugin==2.1.7
+cloudformation-cli-python-lib==2.1.16
+cloudformation-cli-python-plugin==2.1.8
 cloudformation-cli-java-plugin==2.0.12
 cloudformation-cli-typescript-plugin==1.0.1
 cloudformation-cli-go-plugin==2.0.4

--- a/resources/Account_AlternateContact/requirements.txt
+++ b/resources/Account_AlternateContact/requirements.txt
@@ -1,3 +1,1 @@
-cryptography<40.0.0
-cloudformation-cli-python-lib>=2.1.9
-cryptography<40.0.0
+cloudformation-cli-python-lib>=2.1.16

--- a/resources/CloudFront_WebACLAssociation/requirements.txt
+++ b/resources/CloudFront_WebACLAssociation/requirements.txt
@@ -1,2 +1,1 @@
-cryptography<40.0.0
-cloudformation-cli-python-lib>=2.1.9
+cloudformation-cli-python-lib>=2.1.16

--- a/resources/DynamoDB_Item/requirements-dev.txt
+++ b/resources/DynamoDB_Item/requirements-dev.txt
@@ -1,6 +1,6 @@
 cfn-lint==0.73.1
 cloudformation-cli==0.2.28
-cloudformation-cli-python-lib==2.1.15
+cloudformation-cli-python-lib>2.1.15
 git+https://github.com/aws-cloudformation/cloudformation-cli-python-plugin.git
 pylint==2.15.2
 pytest==7.2.0

--- a/resources/DynamoDB_Item/requirements.txt
+++ b/resources/DynamoDB_Item/requirements.txt
@@ -1,3 +1,1 @@
-cryptography<40.0.0
-cloudformation-cli-python-lib>=2.1.15
-cryptography<40.0.0
+cloudformation-cli-python-lib>2.1.15

--- a/resources/S3_BucketNotification/requirements-dev.txt
+++ b/resources/S3_BucketNotification/requirements-dev.txt
@@ -1,8 +1,8 @@
 importlib_metadata==4.7.1
 cfn-lint==0.64.1
 cloudformation-cli==0.2.28
-cloudformation-cli-python-lib==2.1.15
-cloudformation-cli-python-plugin==2.1.7
+cloudformation-cli-python-lib==2.1.16
+cloudformation-cli-python-plugin==2.1.8
 pylint==2.15.2
 pytest==7.2.0
 bandit==1.7.4

--- a/resources/S3_BucketNotification/requirements.txt
+++ b/resources/S3_BucketNotification/requirements.txt
@@ -1,3 +1,1 @@
-cryptography<40.0.0
-cloudformation-cli-python-lib>=2.1.9
-cryptography<40.0.0
+cloudformation-cli-python-lib>=2.1.16

--- a/resources/S3_DeleteBucketContents/requirements-dev.txt
+++ b/resources/S3_DeleteBucketContents/requirements-dev.txt
@@ -1,6 +1,6 @@
 cfn-lint==0.64.1
 cloudformation-cli==0.2.28
-cloudformation-cli-python-lib==2.1.15
-cloudformation-cli-python-plugin==2.1.7
+cloudformation-cli-python-lib==2.1.16
+cloudformation-cli-python-plugin==2.1.8
 pylint==2.15.2
 pytest==7.2.0

--- a/resources/S3_DeleteBucketContents/requirements.txt
+++ b/resources/S3_DeleteBucketContents/requirements.txt
@@ -1,3 +1,1 @@
-cryptography<40.0.0
-cloudformation-cli-python-lib>=2.1.15
-cryptography<40.0.0
+cloudformation-cli-python-lib>=2.1.16

--- a/resources/alpha-buildspec-python.yml
+++ b/resources/alpha-buildspec-python.yml
@@ -14,7 +14,6 @@ phases:
       - echo ENTRY_PATH is $ENTRY_PATH
       - BUILD_FILE_NAME=$(cat ENTRY_PATH | sed s/_/-/g)
       - BUILD_FILE_NAME="${BUILD_FILE_NAME}.zip"
-      - pip install "cryptography<40.0.0"
       - pip install git+https://github.com/aws-cloudformation/cloudformation-cli-python-plugin.git@master
       - cd $RESOURCE_PATH
       - which python


### PR DESCRIPTION
Closes #200 

cloudformation-cli-python-lib >= 2.1.16
cloudformation-cli-python-plugin >= 2.1.8

fixes a broken cryptography dependency

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
