### PR TITLE
Add comma-delimiter escaping logic, update pagination logic.

### DIFF
--- a/resources/Resource_Lookup/src/main/java/com/awscommunity/resource/lookup/LookupHelper.java
+++ b/resources/Resource_Lookup/src/main/java/com/awscommunity/resource/lookup/LookupHelper.java
@@ -100,4 +100,51 @@ public final class LookupHelper {
 
         return result.asBoolean() || !result.isEmpty();
     }
+
+    /**
+     * Escapes a given input string's delimiter (`,`) with an escape character
+     * (`\`). Given an input such as `test,test`, the output that this method
+     * produces is `test\,test`.
+     *
+     * @param input
+     *            {@link String}
+     * @return {@link String} escaped string
+     */
+    public static String escapeCommaDelimiters(final String input) {
+        // Replace the comma delimiter with a backslash, that is here represented with 4
+        // backslash characters to compensate for invalid escape sequence errors as part
+        // of the escaping intent. The output string will only have 1 backslash
+        // character.
+        return input.replaceAll(",", "\\\\,");
+    }
+
+    /**
+     * Unescapes a given input string's delimiter (`,`) by removing the preceding
+     * escape character (`\`). Given an input such as `test\,test`, the output that
+     * this method produces is `test,test`.
+     *
+     * @param input
+     *            {@link String}
+     * @return {@link String} unescaped string
+     */
+    public static String unescapeCommaDelimiters(final String input) {
+        // Replace a backslash character (here represented with 4 backslashes; see
+        // escapeCommaDelimiters()) and a subsequent comma delimiter with just a comma.
+        return input.replaceAll("\\\\,", ",");
+    }
+
+    /**
+     * Splits a comma-delimited input string if commas are not preceded by a `\`
+     * escape character.
+     *
+     * @param input
+     *            {@link String}
+     * @return Array of {@link String}
+     */
+    public static String[] splitStringWithUnescapedCommaDelimiters(final String input) {
+        // Use a negative lookbehind regular expression to match a comma that is not
+        // preceded by a `\` escape character, that is here represented with 4
+        // backslashes; see escapeCommaDelimiters().
+        return input.split("(?<!\\\\),");
+    }
 }

--- a/resources/Resource_Lookup/src/test/java/com/awscommunity/resource/lookup/LookupHelperTest.java
+++ b/resources/Resource_Lookup/src/test/java/com/awscommunity/resource/lookup/LookupHelperTest.java
@@ -32,6 +32,99 @@ public class LookupHelperTest {
     }
 
     @Test
+    public void escapeCommaDelimitersNoCommasInInputMatchesExpectedOutput() {
+        final String input = "test";
+        final String output = LookupHelper.escapeCommaDelimiters(input);
+
+        assertThat(output).isEqualTo("test");
+    }
+
+    @Test
+    public void escapeCommaDelimitersWithOneCommaInInputMatchesExpectedOutput() {
+        final String input = "test,test";
+        final String output = LookupHelper.escapeCommaDelimiters(input);
+
+        assertThat(output).isEqualTo("test\\,test");
+    }
+
+    @Test
+    public void escapeCommaDelimitersWithMoreThanOneCommaInInputMatchesExpectedOutput() {
+        final String input = "test,test,";
+        final String output = LookupHelper.escapeCommaDelimiters(input);
+
+        assertThat(output).isEqualTo("test\\,test\\,");
+    }
+
+    @Test
+    public void unescapeCommaDelimitersNoCommasInInputMatchesExpectedOutput() {
+        final String input = "test";
+        final String output = LookupHelper.unescapeCommaDelimiters(input);
+
+        assertThat(output).isEqualTo("test");
+    }
+
+    @Test
+    public void unescapeCommaDelimitersWithOneCommaInInputMatchesExpectedOutput() {
+        final String input = "test\\,test";
+        final String output = LookupHelper.unescapeCommaDelimiters(input);
+
+        assertThat(output).isEqualTo("test,test");
+    }
+
+    @Test
+    public void unescapeCommaDelimitersWithMoreThanOneCommaInInputMatchesExpectedOutput() {
+        final String input = "test\\,test\\,";
+        final String output = LookupHelper.unescapeCommaDelimiters(input);
+
+        assertThat(output).isEqualTo("test,test,");
+    }
+
+    @Test
+    public void splitStringWithUnescapedCommaDelimitersNoCommasInInputMatchesExpectedOutput() {
+        final String input = "test";
+        final String[] output = LookupHelper.splitStringWithUnescapedCommaDelimiters(input);
+
+        assertThat(output[0]).isEqualTo("test");
+    }
+
+    @Test
+    public void splitStringWithUnescapedCommaDelimitersOneUnescapedCommaInInputMatchesExpectedOutput() {
+        final String input = "test1,test2";
+        final String[] output = LookupHelper.splitStringWithUnescapedCommaDelimiters(input);
+
+        assertThat(output[0]).isEqualTo("test1");
+        assertThat(output[1]).isEqualTo("test2");
+    }
+
+    @Test
+    public void splitStringWithUnescapedCommaDelimitersOneEscapedCommaInInputMatchesExpectedOutput() {
+        final String input = "test1,test2\\,test3";
+        final String[] output = LookupHelper.splitStringWithUnescapedCommaDelimiters(input);
+
+        assertThat(output[0]).isEqualTo("test1");
+        assertThat(output[1]).isEqualTo("test2\\,test3");
+    }
+
+    @Test
+    public void splitStringWithUnescapedCommaDelimitersMoreThanOneUnescapedCommaInInputMatchesExpectedOutput() {
+        final String input = "test1\\,test2,test3,test4";
+        final String[] output = LookupHelper.splitStringWithUnescapedCommaDelimiters(input);
+
+        assertThat(output[0]).isEqualTo("test1\\,test2");
+        assertThat(output[1]).isEqualTo("test3");
+        assertThat(output[2]).isEqualTo("test4");
+    }
+
+    @Test
+    public void splitStringWithUnescapedCommaDelimitersMoreThanOneEscapedCommaInInputMatchesExpectedOutput() {
+        final String input = "test1\\,test2,test3\\,test4";
+        final String[] output = LookupHelper.splitStringWithUnescapedCommaDelimiters(input);
+
+        assertThat(output[0]).isEqualTo("test1\\,test2");
+        assertThat(output[1]).isEqualTo("test3\\,test4");
+    }
+
+    @Test
     public void isIdentifiersBufferNullOrEmptyBufferNull() {
         final List<String> input = null;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add comma-delimiter escaping logic when persisting data into Parameter Store: this helps with resource identifiers that allow a comma, for example `AWS::IAM::Role`;
- Expunged the `currentContext.setResourceLookupId(identifier);` line, that incorrectly stores the resource identifier in the callback context: not only using the callback context for the model is not needed (as it is consumable from the model across invocations), but when a pagination occurs the line above this will set the resource ID (result of the search) as what it will be the Parameter Store parameter name, which is not correct.

### Tests excerpts

#### Unit tests excerpts
```
[...]
[INFO] Tests run: 74, Failures: 0, Errors: 0, Skipped: 0
[...]
[INFO] --- jacoco:0.8.9:check (jacoco-check) @ awscommunity-resource-lookup-handler ---
[...]
[INFO] Analyzed bundle 'awscommunity-resource-lookup-handler' with 10 classes
[INFO] All coverage checks have been met.
```

#### Contract tests excerpts
```
[...]
13 passed, 2 skipped, 9 deselected
[...]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
