### PR TITLE
removed cfn-lint from requirements-dev.txt in hooks/S3_PublicAccess

### DIFF
--- a/hooks/S3_PublicAccessControlsRestricted/requirements-dev.txt
+++ b/hooks/S3_PublicAccessControlsRestricted/requirements-dev.txt
@@ -1,4 +1,3 @@
-cfn-lint==0.73.1
 git+https://github.com/aws-cloudformation/cloudformation-cli.git@master
 cloudformation-cli-python-lib>2.1.15
 cloudformation-cli-python-plugin>2.1.7


### PR DESCRIPTION
cfn-lint dependency in hooks/S3_PublicAccessControlsRestricted/requirements-dev.txt file was causing testing failures with newest cloudformation-cli version.  This dependency was removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
