### PR TITLE
Reduce Java build verbosity; update runorder

### DIFF
--- a/hooks/alpha-buildspec-java.yml
+++ b/hooks/alpha-buildspec-java.yml
@@ -31,7 +31,7 @@ phases:
       - cfn generate
       - SETUP_STACK_NAME="setup-$(echo $TYPE_CLEAN_NAME | sed s/_/-/g)"
       - if [ -f test/setup.yml ]; then rain deploy test/setup.yml $SETUP_STACK_NAME -y; fi
-      - mvn clean verify javadoc:javadoc
+      - mvn clean verify javadoc:javadoc -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - cfn submit --dry-run
       - ls -ltra
       - nohup sam local start-lambda &

--- a/hooks/beta-buildspec-java.yml
+++ b/hooks/beta-buildspec-java.yml
@@ -24,7 +24,7 @@ phases:
       - echo Entered the build phase...
       - cfn validate
       - cfn generate
-      - mvn clean verify javadoc:javadoc
+      - mvn clean verify javadoc:javadoc -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - cfn submit --set-default
       - HOOK_TYPE_ARN=$(aws cloudformation list-types --visibility PRIVATE --type HOOK --filters TypeNamePrefix=$TYPE_NAME --output json | jq -r '.TypeSummaries[0].TypeArn')
       - aws cloudformation set-type-configuration --configuration file://test/configuration.json --type-arn $HOOK_TYPE_ARN

--- a/hooks/prod-buildspec-java.yml
+++ b/hooks/prod-buildspec-java.yml
@@ -22,7 +22,7 @@ phases:
   build:
     commands:
       - echo Entered the build phase...
-      - mvn clean verify javadoc:javadoc
+      - mvn clean verify javadoc:javadoc -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - ls -l ../../release
       - ../../release/publish-regions.sh
     finally:

--- a/release/awscommunity/cicd.yml
+++ b/release/awscommunity/cicd.yml
@@ -1952,7 +1952,7 @@ IotAnalyticsPipelineModuleBuildProject:
                       "value": "hooks/KMS_EncryptionSettings"
                     }
                   ]
-              RunOrder: 4
+              RunOrder: 5
             - Name: ApplicationAutoscalingScheduledAction
               InputArtifacts:
                 - Name: extensions-source

--- a/resources/alpha-buildspec-java.yml
+++ b/resources/alpha-buildspec-java.yml
@@ -31,7 +31,7 @@ phases:
       - cfn generate
       - SETUP_STACK_NAME="setup-$(echo $TYPE_CLEAN_NAME | sed s/_/-/g)"
       - if [ -f test/setup.yml ]; then rain deploy test/setup.yml $SETUP_STACK_NAME -y; fi
-      - mvn clean verify javadoc:javadoc
+      - mvn clean verify javadoc:javadoc -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - ls -ltra
       - nohup sam local start-lambda &
       - sleep 10

--- a/resources/beta-buildspec-java.yml
+++ b/resources/beta-buildspec-java.yml
@@ -26,7 +26,7 @@ phases:
       - cfn validate
       - cfn generate
       - ../../release/deregister-all.sh us-east-1 RESOURCE
-      - mvn clean verify javadoc:javadoc
+      - mvn clean verify javadoc:javadoc -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - cfn submit --set-default
       - INTEG_STACK_NAME="integ-$(echo $TYPE_CLEAN_NAME | sed s/_/-/g)"
       - rain deploy test/integ.yml $INTEG_STACK_NAME -y

--- a/resources/prod-buildspec-java.yml
+++ b/resources/prod-buildspec-java.yml
@@ -22,7 +22,7 @@ phases:
   build:
     commands:
       - echo Entered the build phase...
-      - mvn clean verify javadoc:javadoc
+      - mvn clean verify javadoc:javadoc -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - ls -l ../../release
       - ../../release/publish-regions.sh
     finally:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Reduce Java build verbosity by using batch mode to reduce trasfer verbosity for the logging facility used; we could have instead used `-ntp` or `--no-transfer-progress` instead, but choosing the other approach in the event the `mvn` version used would not support that.  Also, we could reuse the former approach to reduce verbosity of other packages, as needed. 
- Update runorder for the KMS-related hook in Java.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
