### PR TITLE
chore(deps): cloudformation-cli and cfn-lint dependency updates

### DIFF
--- a/hooks/CloudFront_LoggingEnabled/requirements-dev.txt
+++ b/hooks/CloudFront_LoggingEnabled/requirements-dev.txt
@@ -1,4 +1,4 @@
-cfn-lint==0.64.1
+cfn-lint==0.78.1
 cloudformation-cli==0.2.33
 cloudformation-cli-python-lib>2.1.15
 cloudformation-cli-python-plugin>2.1.7

--- a/hooks/CloudFront_LoggingEnabled/requirements-dev.txt
+++ b/hooks/CloudFront_LoggingEnabled/requirements-dev.txt
@@ -1,5 +1,5 @@
 cfn-lint==0.64.1
-cloudformation-cli==0.2.28
+cloudformation-cli==0.2.33
 cloudformation-cli-python-lib>2.1.15
 cloudformation-cli-python-plugin>2.1.7
 pylint==2.15.2

--- a/hooks/EC2_SecurityGroupRestrictedSSH/requirements-dev.txt
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/requirements-dev.txt
@@ -1,4 +1,4 @@
-cfn-lint==0.64.1
+cfn-lint==0.78.1
 cloudformation-cli==0.2.33
 cloudformation-cli-python-lib>2.1.15
 cloudformation-cli-python-plugin>2.1.7

--- a/hooks/EC2_SecurityGroupRestrictedSSH/requirements-dev.txt
+++ b/hooks/EC2_SecurityGroupRestrictedSSH/requirements-dev.txt
@@ -1,5 +1,5 @@
 cfn-lint==0.64.1
-cloudformation-cli==0.2.28
+cloudformation-cli==0.2.33
 cloudformation-cli-python-lib>2.1.15
 cloudformation-cli-python-plugin>2.1.7
 pylint==2.15.2

--- a/hooks/KMS_EncryptionSettings/requirements-dev.txt
+++ b/hooks/KMS_EncryptionSettings/requirements-dev.txt
@@ -1,6 +1,6 @@
 # To install the following requirements, run:
 #   python3 -m pip install -r requirements-dev.txt
-cloudformation-cli>=0.2.28
+cloudformation-cli>=0.2.33
 cloudformation-cli-java-plugin>=2.0.14
 cloudformation-cli-python-lib>2.1.15
 pytest>=7.2.0

--- a/hooks/S3_BucketVersioningEnabled/requirements-dev.txt
+++ b/hooks/S3_BucketVersioningEnabled/requirements-dev.txt
@@ -1,4 +1,4 @@
-cfn-lint==0.64.1
+cfn-lint==0.78.1
 cloudformation-cli==0.2.33
 cloudformation-cli-python-lib>2.1.15
 cloudformation-cli-python-plugin>2.1.7

--- a/hooks/S3_BucketVersioningEnabled/requirements-dev.txt
+++ b/hooks/S3_BucketVersioningEnabled/requirements-dev.txt
@@ -1,5 +1,5 @@
 cfn-lint==0.64.1
-cloudformation-cli==0.2.28
+cloudformation-cli==0.2.33
 cloudformation-cli-python-lib>2.1.15
 cloudformation-cli-python-plugin>2.1.7
 pylint==2.15.2

--- a/release/requirements.txt
+++ b/release/requirements.txt
@@ -1,6 +1,6 @@
 importlib_metadata==4.7.1
 cfn-lint==0.64.1
-cloudformation-cli==0.2.28
+cloudformation-cli==0.2.33
 cloudformation-cli-python-lib==2.1.16
 cloudformation-cli-python-plugin==2.1.8
 cloudformation-cli-java-plugin==2.0.12

--- a/release/requirements.txt
+++ b/release/requirements.txt
@@ -1,5 +1,5 @@
 importlib_metadata==4.7.1
-cfn-lint==0.64.1
+cfn-lint==0.78.1
 cloudformation-cli==0.2.33
 cloudformation-cli-python-lib==2.1.16
 cloudformation-cli-python-plugin==2.1.8

--- a/resources/ApplicationAutoscaling_ScheduledAction/requirements-dev.txt
+++ b/resources/ApplicationAutoscaling_ScheduledAction/requirements-dev.txt
@@ -1,5 +1,5 @@
 importlib_metadata==4.7.1
-cfn-lint==0.64.1
+cfn-lint==0.78.1
 cloudformation-cli-python-lib==2.1.16
 git+https://github.com/aws-cloudformation/cloudformation-cli.git@master
 git+https://github.com/aws-cloudformation/cloudformation-cli-python-plugin.git@master

--- a/resources/DynamoDB_Item/requirements-dev.txt
+++ b/resources/DynamoDB_Item/requirements-dev.txt
@@ -1,5 +1,5 @@
 cfn-lint==0.73.1
-cloudformation-cli==0.2.28
+cloudformation-cli==0.2.33
 cloudformation-cli-python-lib>2.1.15
 git+https://github.com/aws-cloudformation/cloudformation-cli-python-plugin.git
 pylint==2.15.2

--- a/resources/DynamoDB_Item/requirements-dev.txt
+++ b/resources/DynamoDB_Item/requirements-dev.txt
@@ -1,4 +1,4 @@
-cfn-lint==0.73.1
+cfn-lint==0.78.1
 cloudformation-cli==0.2.33
 cloudformation-cli-python-lib>2.1.15
 git+https://github.com/aws-cloudformation/cloudformation-cli-python-plugin.git

--- a/resources/S3_BucketNotification/requirements-dev.txt
+++ b/resources/S3_BucketNotification/requirements-dev.txt
@@ -1,5 +1,5 @@
 importlib_metadata==4.7.1
-cfn-lint==0.64.1
+cfn-lint==0.78.1
 cloudformation-cli==0.2.33
 cloudformation-cli-python-lib==2.1.16
 cloudformation-cli-python-plugin==2.1.8

--- a/resources/S3_BucketNotification/requirements-dev.txt
+++ b/resources/S3_BucketNotification/requirements-dev.txt
@@ -1,6 +1,6 @@
 importlib_metadata==4.7.1
 cfn-lint==0.64.1
-cloudformation-cli==0.2.28
+cloudformation-cli==0.2.33
 cloudformation-cli-python-lib==2.1.16
 cloudformation-cli-python-plugin==2.1.8
 pylint==2.15.2

--- a/resources/S3_DeleteBucketContents/requirements-dev.txt
+++ b/resources/S3_DeleteBucketContents/requirements-dev.txt
@@ -1,4 +1,4 @@
-cfn-lint==0.64.1
+cfn-lint==0.78.1
 cloudformation-cli==0.2.33
 cloudformation-cli-python-lib==2.1.16
 cloudformation-cli-python-plugin==2.1.8

--- a/resources/S3_DeleteBucketContents/requirements-dev.txt
+++ b/resources/S3_DeleteBucketContents/requirements-dev.txt
@@ -1,5 +1,5 @@
 cfn-lint==0.64.1
-cloudformation-cli==0.2.28
+cloudformation-cli==0.2.33
 cloudformation-cli-python-lib==2.1.16
 cloudformation-cli-python-plugin==2.1.8
 pylint==2.15.2

--- a/resources/Time_Offset/requirements.txt
+++ b/resources/Time_Offset/requirements.txt
@@ -1,2 +1,2 @@
-cloudformation-cli==0.2.28
+cloudformation-cli==0.2.33
 cloudformation-cli-go-plugin==2.0.4

--- a/resources/Time_Static/requirements.txt
+++ b/resources/Time_Static/requirements.txt
@@ -1,2 +1,2 @@
-cloudformation-cli==0.2.28
+cloudformation-cli==0.2.33
 cloudformation-cli-go-plugin==2.0.4


### PR DESCRIPTION
Cython update has issues with older versions of PyYaml.  Updating cloudformation-cli and cfn-lint to resolve this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
