### PR TITLE
Declare TypeConfigurationModel as nullable.

### DIFF
--- a/hooks/S3_AccessControl/src/main/kotlin/com/awscommunity/s3/accesscontrol/BaseHookHandlerStd.kt
+++ b/hooks/S3_AccessControl/src/main/kotlin/com/awscommunity/s3/accesscontrol/BaseHookHandlerStd.kt
@@ -29,7 +29,7 @@ abstract class BaseHookHandlerStd : BaseHookHandler<CallbackContext?, TypeConfig
         request: HookHandlerRequest,
         callbackContext: CallbackContext?,
         logger: Logger,
-        typeConfiguration: TypeConfigurationModel
+        typeConfiguration: TypeConfigurationModel?
     ): ProgressEvent<HookTargetModel, CallbackContext?> {
         val targetModel = request.hookContext.getTargetModel(AwsS3BucketTargetModel::class.java)
         val resourceProperties = targetModel.resourceProperties

--- a/hooks/S3_AccessControl/src/main/kotlin/com/awscommunity/s3/accesscontrol/PreCreateHookHandler.kt
+++ b/hooks/S3_AccessControl/src/main/kotlin/com/awscommunity/s3/accesscontrol/PreCreateHookHandler.kt
@@ -25,7 +25,7 @@ open class PreCreateHookHandler : BaseHookHandlerStd() {
         request: HookHandlerRequest,
         callbackContext: CallbackContext?,
         logger: Logger,
-        typeConfiguration: TypeConfigurationModel
+        typeConfiguration: TypeConfigurationModel?
     ): ProgressEvent<HookTargetModel, CallbackContext?> {
         return handlePreCreatePreUpdateRequests(proxy, request, callbackContext, logger, typeConfiguration)
     }

--- a/hooks/S3_AccessControl/src/main/kotlin/com/awscommunity/s3/accesscontrol/PreUpdateHookHandler.kt
+++ b/hooks/S3_AccessControl/src/main/kotlin/com/awscommunity/s3/accesscontrol/PreUpdateHookHandler.kt
@@ -25,7 +25,7 @@ open class PreUpdateHookHandler : BaseHookHandlerStd() {
         request: HookHandlerRequest,
         callbackContext: CallbackContext?,
         logger: Logger,
-        typeConfiguration: TypeConfigurationModel
+        typeConfiguration: TypeConfigurationModel?
     ): ProgressEvent<HookTargetModel, CallbackContext?> {
         return handlePreCreatePreUpdateRequests(proxy, request, callbackContext, logger, typeConfiguration)
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Declare `TypeConfigurationModel` as nullable: useful when running contract tests without a `~/.cfn-cli/typeConfiguration.json` file. I ran contract tests (see excerpts below) without the `~/.cfn-cli/typeConfiguration.json` file on my workstation this time, to verify this specific use case.

### Unit tests excerpts
```
[INFO] Running com.awscommunity.s3.accesscontrol.PreUpdateHookHandlerTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.844 s -- in com.awscommunity.s3.accesscontrol.PreUpdateHookHandlerTest
[INFO] Running com.awscommunity.s3.accesscontrol.PreCreateHookHandlerTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.023 s -- in com.awscommunity.s3.accesscontrol.PreCreateHookHandlerTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0
[...]
[INFO] --- jacoco:0.8.10:check (jacoco-check) @ awscommunity-s3-accesscontrol-handler ---
[...]
[INFO] Analyzed bundle 'awscommunity-s3-accesscontrol-handler' with 5 classes
[INFO] All coverage checks have been met.
```

### Contract tests excerpts
```
collected 24 items / 17 deselected / 7 selected                                                                                                                                                            

[...]/hook/handler_pre_create.py::contract_pre_create_success PASSED                                                    [ 14%]
[...]/hook/handler_pre_create.py::contract_pre_create_failed PASSED                                                     [ 28%]
[...]/hook/handler_pre_create.py::contract_pre_create_failed_unsupported_target SKIPPED (No wildcard hook targets. ...) [ 42%]
[...]/hook/handler_pre_update.py::contract_pre_update_success PASSED                                                    [ 57%]
[...]/hook/handler_pre_update.py::contract_pre_update_failed PASSED                                                     [ 71%]
[...]/hook/handler_pre_update.py::contract_pre_update_failed_unsupported_target SKIPPED (No wildcard hook targets. ...) [ 85%]
[...]/resource/handler_misc.py::contract_check_asserts_work PASSED                                                      [100%]
[...]
5 passed, 2 skipped, 17 deselected [...]
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
