### PR TITLE
Fix example in AppSync hook README.md

### DIFF
--- a/hooks/AppSync_BreakingChangeDetection/README.md
+++ b/hooks/AppSync_BreakingChangeDetection/README.md
@@ -171,7 +171,8 @@ Resources:
           }
           
           enum TestType {
-             SIMPLE,
+             SIMPLE
              COMPLEX
+             COMPOUND
           }
 ```


### PR DESCRIPTION
Example missed the addition of new Enum value. 
