### PR TITLE
Add s3:DeleteObjectVersion action to AwsCommunity::S3::DeleteBucketCo…

### DIFF
--- a/resources/S3_DeleteBucketContents/awscommunity-s3-deletebucketcontents.json
+++ b/resources/S3_DeleteBucketContents/awscommunity-s3-deletebucketcontents.json
@@ -39,6 +39,7 @@
         "delete": {
             "permissions": [
                 "s3:DeleteObject",
+                "s3:DeleteObjectVersion",
                 "s3:ListBucket",
                 "s3:ListBucketVersions",
                 "s3:GetBucketTagging",

--- a/resources/S3_DeleteBucketContents/resource-role-prod.yaml
+++ b/resources/S3_DeleteBucketContents/resource-role-prod.yaml
@@ -24,6 +24,7 @@ Resources:
               - Effect: Allow
                 Action:
                 - "s3:DeleteObject"
+                - "s3:DeleteObjectVersion"
                 - "s3:GetBucketTagging"
                 - "s3:ListBucket"
                 - "s3:ListBucketVersions"

--- a/resources/S3_DeleteBucketContents/resource-role.yaml
+++ b/resources/S3_DeleteBucketContents/resource-role.yaml
@@ -24,6 +24,7 @@ Resources:
               - Effect: Allow
                 Action:
                 - "s3:DeleteObject"
+                - "s3:DeleteObjectVersion"
                 - "s3:GetBucketTagging"
                 - "s3:ListBucket"
                 - "s3:ListBucketVersions"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added s3:DeleteObjectVersion permission to AwsCommunity::S3::DeleteBucketContents extension role to properly handle object deletion in versioning-enabled buckets.
